### PR TITLE
add type argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `orbital()` gained `prefix` argument to allow for renaming of prediction columns. (#59)
 
-* `orbital()` now works with `logistic_reg()` models. (#62)
+* `orbital()` now works with `logistic_reg()` models for class prediction and probability predictions. (#62, #66)
 
 * `orbital()` has gained `type` argument to change prediction type. (#66)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * `orbital()` now works with `logistic_reg()` models. (#62)
 
+* `orbital()` has gained `type` argument to change prediction type. (#66)
+
 # orbital 0.2.0
 
 * Support for `step_dummy()`,  `step_impute_mean()`, `step_impute_median()`, `step_impute_mode()`,  `step_unknown()`, `step_novel()`, `step_other()`, `step_BoxCox()`, `step_inverse()`, `step_mutate()`, `step_sqrt()`, `step_indicate_na()`, `step_range()`, `step_intercept()`, `step_ratio()`, `step_lag()`, `step_log()`, `step_rename()` has been added. (#17)

--- a/R/model-glm.R
+++ b/R/model-glm.R
@@ -14,7 +14,9 @@ orbital.glm <- function(
 		eq <- tidypredict::tidypredict_fit(x)
 		eq <- deparse1(eq)
 
-		type <- type %||% "class"
+		if (is.null(type)) {
+			type <- "class"
+		}
 
 		res <- NULL
 		if ("class" %in% type) {

--- a/R/model-glm.R
+++ b/R/model-glm.R
@@ -1,16 +1,37 @@
 #' @export
-orbital.glm <- function(x, ..., mode = c("classification", "regression")) {
+orbital.glm <- function(
+	x,
+	...,
+	mode = c("classification", "regression"),
+	type = NULL
+) {
 	mode <- rlang::arg_match(mode)
 
 	if (mode == "classification") {
-    outcome <- names(attr(x$terms, "dataClasses"))[attr(x$terms, "response")]
+		outcome <- names(attr(x$terms, "dataClasses"))[attr(x$terms, "response")]
 		levels <- levels(x$data[[outcome]])
 		levels <- glue::double_quote(levels)
-		res <- tidypredict::tidypredict_fit(x)
-		res <- deparse1(res)
-		res <- glue::glue(
-			"dplyr::case_when({res} < 0.5 ~ {levels[1]}, .default = {levels[2]})"
-		)
+		eq <- tidypredict::tidypredict_fit(x)
+		eq <- deparse1(eq)
+
+		type <- type %||% "class"
+
+		res <- NULL
+		if ("class" %in% type) {
+			res <- c(
+				res,
+				glue::glue(
+					"dplyr::case_when({eq} < 0.5 ~ {levels[1]}, .default = {levels[2]})"
+				)
+			)
+		}
+		if ("prob" %in% type) {
+			res <- c(
+				res,
+				glue::glue("1 - ({eq})"),
+				glue::glue("{eq}")
+			)
+		}
 	} else if (mode == "regression") {
 		res <- tidypredict::tidypredict_fit(x)
 	}

--- a/R/orbital.R
+++ b/R/orbital.R
@@ -10,6 +10,11 @@
 #'   If `x` produces a prediction, tidymodels standards dictate that the
 #'   predictions will start with `.pred`. This is not a valid name for
 #'   some data bases.
+#' @param type A vector of strings, specifies the prediction type. Regression
+#'   models allow for `"numeric"` and classification models allow for `"class"`
+#'   and `"prob"`. Multiple values are allowed to produce hard and soft
+#'   predictions for classification models. Defaults to `NULL` which defaults to
+#'   `"numeric"` for regression models and `"class"` for classification models.
 #'
 #' @returns An [orbital] object.
 #'
@@ -58,7 +63,7 @@
 #'   orbital()
 #'
 #' @export
-orbital <- function(x, ..., prefix = ".pred") {
+orbital <- function(x, ..., prefix = ".pred", type = NULL) {
 	UseMethod("orbital")
 }
 

--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -4,7 +4,7 @@ orbital.model_fit <- function(x, ..., prefix = ".pred", type = NULL) {
 	check_mode(mode)
 	check_type(type, mode)
 
-	res <- try(orbital(x$fit, mode = mode), silent = TRUE)
+	res <- try(orbital(x$fit, mode = mode, type = type), silent = TRUE)
 
 	if (inherits(res, "try-error")) {
 		res <- tryCatch(
@@ -26,14 +26,25 @@ orbital.model_fit <- function(x, ..., prefix = ".pred", type = NULL) {
 	}
 
 	if (mode == "classification") {
-		prefix <- paste0(prefix, "_class")
+		names <- NULL
+		type <- type %||% "class"
+		if ("class" %in% type) {
+			names <- c(names, paste0(prefix, "_class"))
+		}
+		if ("prob" %in% type) {
+			names <- c(names, paste0(prefix, "_", x$lvl))
+		}
+	}
+	if (mode == "regression") {
+		names <- prefix
 	}
 
 	if (is.language(res)) {
 		res <- deparse1(res)
 	}
 
-	res <- stats::setNames(res, prefix)
+	attr(res, "pred_names") <- names
+	res <- stats::setNames(res, names)
 
 	new_orbital_class(res)
 }

--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -65,14 +65,14 @@ check_type <- function(type, mode, call = rlang::caller_env()) {
 
 	if (mode == "regression" && any(!type %in% "numeric")) {
 		cli::cli_abort(
-			"{.arg type} can only be {.val numeric} for models with mode 
+			"{.arg type} can only be {.val numeric} for model with mode 
 			{.val regression}, not {.val {type}}.",
 			call = call
 		)
 	}
 	if (mode == "classification" && any(!type %in% c("class", "prob"))) {
 		cli::cli_abort(
-			"{.arg type} can only be {.val class} or {.val prob} for models with mode 
+			"{.arg type} can only be {.val class} or {.val prob} for model with mode 
 			{.val classification}, not {.val {type}}.",
 			call = call
 		)

--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -27,7 +27,11 @@ orbital.model_fit <- function(x, ..., prefix = ".pred", type = NULL) {
 
 	if (mode == "classification") {
 		names <- NULL
-		type <- type %||% "class"
+
+		if (is.null(type)) {
+			type <- "class"
+		}
+
 		if ("class" %in% type) {
 			names <- c(names, paste0(prefix, "_class"))
 		}

--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -1,8 +1,8 @@
 #' @export
-orbital.model_fit <- function(x, ..., prefix = ".pred") {
+orbital.model_fit <- function(x, ..., prefix = ".pred", type = NULL) {
 	mode <- x$spec$mode
-
 	check_mode(mode)
+	check_type(type, mode)
 
 	res <- try(orbital(x$fit, mode = mode), silent = TRUE)
 
@@ -50,6 +50,30 @@ check_mode <- function(mode, call = rlang::caller_env()) {
 		cli::cli_abort(
 			"Only models with modes {.val {supported_modes}} are supported. 
       Not {.val {mode}}.",
+			call = call
+		)
+	}
+}
+
+check_type <- function(type, mode, call = rlang::caller_env()) {
+	if (is.null(type)) {
+		return(invisible())
+	}
+
+	supported_types <- c("numeric", "class", "prob")
+	rlang::arg_match(type, supported_types, multiple = TRUE, error_call = call)
+
+	if (mode == "regression" && any(!type %in% "numeric")) {
+		cli::cli_abort(
+			"{.arg type} can only be {.val numeric} for models with mode 
+			{.val regression}, not {.val {type}}.",
+			call = call
+		)
+	}
+	if (mode == "classification" && any(!type %in% c("class", "prob"))) {
+		cli::cli_abort(
+			"{.arg type} can only be {.val class} or {.val prob} for models with mode 
+			{.val classification}, not {.val {type}}.",
 			call = call
 		)
 	}

--- a/R/predict.R
+++ b/R/predict.R
@@ -38,8 +38,10 @@ predict.orbital_class <- function(object, new_data, ...) {
 	rlang::check_dots_empty()
 	res <- dplyr::mutate(new_data, !!!orbital_inline(object))
 
-	pred_name <- names(object)[length(object)]
-	res <- dplyr::select(res, dplyr::any_of(pred_name))
+	pred_name <- attr(object, "pred_names")
+	if (!is.null(pred_name)) {
+		res <- dplyr::select(res, dplyr::any_of(pred_name))
+	}
 
 	res
 }

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -1,5 +1,5 @@
 #' @export
-orbital.workflow <- function(x, ..., prefix = ".pred") {
+orbital.workflow <- function(x, ..., prefix = ".pred", type = NULL) {
 	if (!workflows::is_trained_workflow(x)) {
 		cli::cli_abort("{.arg x} must be a fully trained {.cls workflow}.")
 	}
@@ -9,7 +9,7 @@ orbital.workflow <- function(x, ..., prefix = ".pred") {
 	}
 
 	model_fit <- workflows::extract_fit_parsnip(x)
-	out <- orbital(model_fit, prefix = prefix)
+	out <- orbital(model_fit, prefix = prefix, type = type)
 
 	preprocessor <- workflows::extract_preprocessor(x)
 

--- a/R/workflows.R
+++ b/R/workflows.R
@@ -16,7 +16,9 @@ orbital.workflow <- function(x, ..., prefix = ".pred", type = NULL) {
 	if (inherits(preprocessor, "recipe")) {
 		recipe_fit <- workflows::extract_recipe(x)
 
+		pred_names <- attr(out, "pred_names")
 		out <- orbital(recipe_fit, out, prefix = prefix)
+		attr(out, "pred_names") <- pred_names
 	}
 
 	new_orbital_class(out)

--- a/man/orbital.Rd
+++ b/man/orbital.Rd
@@ -4,7 +4,7 @@
 \alias{orbital}
 \title{Turn tidymodels objects into orbital objects}
 \usage{
-orbital(x, ..., prefix = ".pred")
+orbital(x, ..., prefix = ".pred", type = NULL)
 }
 \arguments{
 \item{x}{A fitted workflow, parsnip, or recipes object.}
@@ -15,6 +15,12 @@ orbital(x, ..., prefix = ".pred")
 If \code{x} produces a prediction, tidymodels standards dictate that the
 predictions will start with \code{.pred}. This is not a valid name for
 some data bases.}
+
+\item{type}{A vector of strings, specifies the prediction type. Regression
+models allow for \code{"numeric"} and classification models allow for \code{"class"}
+and \code{"prob"}. Multiple values are allowed to produce hard and soft
+predictions for classification models. Defaults to \code{NULL} which defaults to
+\code{"numeric"} for regression models and \code{"class"} for classification models.}
 }
 \value{
 An \link{orbital} object.

--- a/tests/testthat/_snaps/workflows.md
+++ b/tests/testthat/_snaps/workflows.md
@@ -1,23 +1,7 @@
-# normal usage works works
-
-    Code
-      orbital(wf_fit)
-    Condition
-      Error in `orbital()`:
-      ! A model of class <train.kknn> is not supported.
-
-# errors on invalid modes
-
-    Code
-      orbital(lm_fit)
-    Condition
-      Error in `orbital()`:
-      ! Only models with modes "regression" and "classification" are supported.  Not "invalid mode".
-
 # type argument checking works
 
     Code
-      orbital(lm_fit, type = "invalid")
+      orbital(wf_fit, type = "invalid")
     Condition
       Error in `orbital()`:
       ! `type` must be one of "numeric", "class", or "prob", not "invalid".
@@ -25,7 +9,7 @@
 ---
 
     Code
-      orbital(lm_fit, type = "class")
+      orbital(wf_fit, type = "class")
     Condition
       Error in `orbital()`:
       ! `type` can only be "numeric" for model with mode "regression", not "class".
@@ -33,7 +17,7 @@
 ---
 
     Code
-      orbital(lm_fit, type = c("class", "numeric"))
+      orbital(wf_fit, type = c("class", "numeric"))
     Condition
       Error in `orbital()`:
       ! `type` can only be "numeric" for model with mode "regression", not "class" and "numeric".
@@ -41,7 +25,7 @@
 ---
 
     Code
-      orbital(lm_fit, type = "invalid")
+      orbital(wf_fit, type = "invalid")
     Condition
       Error in `orbital()`:
       ! `type` must be one of "numeric", "class", or "prob", not "invalid".
@@ -49,7 +33,7 @@
 ---
 
     Code
-      orbital(lm_fit, type = "numeric")
+      orbital(wf_fit, type = "numeric")
     Condition
       Error in `orbital()`:
       ! `type` can only be "class" or "prob" for model with mode "classification", not "numeric".
@@ -57,7 +41,7 @@
 ---
 
     Code
-      orbital(lm_fit, type = c("class", "numeric"))
+      orbital(wf_fit, type = c("class", "numeric"))
     Condition
       Error in `orbital()`:
       ! `type` can only be "class" or "prob" for model with mode "classification", not "class" and "numeric".

--- a/tests/testthat/test-json.R
+++ b/tests/testthat/test-json.R
@@ -20,5 +20,8 @@ test_that("read and write json works", {
 
 	new <- orbital_json_read(tmp_file)
 
+	# temp fix
+	attr(orbital_obj, "pred_names") <- NULL
+
 	expect_identical(new, orbital_obj)
 })

--- a/tests/testthat/test-model-glm.R
+++ b/tests/testthat/test-model-glm.R
@@ -1,4 +1,4 @@
-test_that("multiplication works", {
+test_that("logistic_reg() works with type = class", {
 	skip_if_not_installed("parsnip")
 	skip_if_not_installed("tidypredict")
 
@@ -8,7 +8,7 @@ test_that("multiplication works", {
 
 	lr_fit <- parsnip::fit(lr_spec, vs ~ disp + mpg + hp, mtcars)
 
-	orb_obj <- orbital(lr_fit)
+	orb_obj <- orbital(lr_fit, type = "class")
 
 	preds <- predict(orb_obj, mtcars)
 	exps <- predict(lr_fit, mtcars)
@@ -19,5 +19,35 @@ test_that("multiplication works", {
 	expect_identical(
 		preds$.pred_class,
 		as.character(exps$.pred_class)
+	)
+})
+
+test_that("logistic_reg() works with type = prob", {
+	skip_if_not_installed("parsnip")
+	skip_if_not_installed("tidypredict")
+
+	mtcars$vs <- factor(mtcars$vs)
+
+	lr_spec <- parsnip::logistic_reg()
+
+	lr_fit <- parsnip::fit(lr_spec, vs ~ disp + mpg + hp, mtcars)
+
+	orb_obj <- orbital(lr_fit, type = "prob")
+
+	preds <- predict(orb_obj, mtcars)
+	exps <- predict(lr_fit, mtcars, type = "prob")
+
+	expect_named(preds, c(".pred_0", ".pred_1"))
+	expect_type(preds$.pred_0, "double")
+	expect_type(preds$.pred_1, "double")
+
+	exps <- as.data.frame(exps)
+
+	rownames(preds) <- NULL
+	rownames(exps) <- NULL
+
+	expect_equal(
+		preds,
+		exps
 	)
 })

--- a/tests/testthat/test-parsnip.R
+++ b/tests/testthat/test-parsnip.R
@@ -59,3 +59,54 @@ test_that("errors on invalid modes", {
 		orbital(lm_fit)
 	)
 })
+
+test_that("type argument checking works", {
+	skip_if_not_installed("tidypredict")
+	lm_spec <- parsnip::linear_reg()
+
+	lm_fit <- parsnip::fit(lm_spec, mpg ~ ., mtcars)
+
+	expect_no_error(
+		orbital(lm_fit, type = "numeric")
+	)
+
+	expect_snapshot(
+		error = TRUE,
+		orbital(lm_fit, type = "invalid")
+	)
+	expect_snapshot(
+		error = TRUE,
+		orbital(lm_fit, type = "class")
+	)
+	expect_snapshot(
+		error = TRUE,
+		orbital(lm_fit, type = c("class", "numeric"))
+	)
+
+	lm_spec <- parsnip::logistic_reg()
+
+	mtcars$vs <- factor(mtcars$vs)
+
+	lm_fit <- parsnip::fit(lm_spec, vs ~ disp, mtcars)
+
+	expect_no_error(
+		orbital(lm_fit, type = "class")
+	)
+
+	expect_no_error(
+		orbital(lm_fit, type = c("class", "prob"))
+	)
+
+	expect_snapshot(
+		error = TRUE,
+		orbital(lm_fit, type = "invalid")
+	)
+	expect_snapshot(
+		error = TRUE,
+		orbital(lm_fit, type = "numeric")
+	)
+	expect_snapshot(
+		error = TRUE,
+		orbital(lm_fit, type = c("class", "numeric"))
+	)
+})

--- a/tests/testthat/test-workflows.R
+++ b/tests/testthat/test-workflows.R
@@ -1,0 +1,59 @@
+test_that("type argument checking works", {
+	skip_if_not_installed("tidypredict")
+	skip_if_not_installed("workflows")
+	lm_spec <- parsnip::linear_reg()
+
+	wf_spec <- workflows::workflow() %>%
+		workflows::add_variables(outcomes = "mpg", predictors = everything()) %>%
+		workflows::add_model(lm_spec)
+
+	wf_fit <- parsnip::fit(wf_spec, mtcars)
+
+	expect_no_error(
+		orbital(wf_fit, type = "numeric")
+	)
+
+	expect_snapshot(
+		error = TRUE,
+		orbital(wf_fit, type = "invalid")
+	)
+	expect_snapshot(
+		error = TRUE,
+		orbital(wf_fit, type = "class")
+	)
+	expect_snapshot(
+		error = TRUE,
+		orbital(wf_fit, type = c("class", "numeric"))
+	)
+
+	lr_spec <- parsnip::logistic_reg()
+
+	mtcars$vs <- factor(mtcars$vs)
+
+	wf_spec <- workflows::workflow() %>%
+		workflows::add_variables(outcomes = "vs", predictors = "disp") %>%
+		workflows::add_model(lr_spec)
+
+	wf_fit <- parsnip::fit(wf_spec, mtcars)
+
+	expect_no_error(
+		orbital(wf_fit, type = "class")
+	)
+
+	expect_no_error(
+		orbital(wf_fit, type = c("class", "prob"))
+	)
+
+	expect_snapshot(
+		error = TRUE,
+		orbital(wf_fit, type = "invalid")
+	)
+	expect_snapshot(
+		error = TRUE,
+		orbital(wf_fit, type = "numeric")
+	)
+	expect_snapshot(
+		error = TRUE,
+		orbital(wf_fit, type = c("class", "numeric"))
+	)
+})

--- a/vignettes/supported-models.Rmd
+++ b/vignettes/supported-models.Rmd
@@ -34,7 +34,7 @@ tibble::tribble(
   "`decision_tree()`",    "`\"partykit\"`",     "✅",     "⚪",    "⚪",
   "`linear_reg()`",       "`\"lm\"`",           "✅",     "❌",    "❌",
   "`linear_reg()`",       "`\"glmnet\"`",       "⚪",     "❌",    "❌",
-  "`logistic_reg()`",     "`\"glm\"`",          "❌",     "✅",    "⚪",
+  "`logistic_reg()`",     "`\"glm\"`",          "❌",     "✅",    "✅",
   "`logistic_reg()`",     "`\"glmnet\"`",       "❌",     "⚪",    "⚪",
   "`mars()`",             "`\"earth\"`",        "✅",     "⚪",    "⚪",
   "`naive_Bayes()`",      "`\"naivebayes\"`",   "❌",     "⚪",    "⚪",


### PR DESCRIPTION
This PR:

- adds `type` argument to `orbital()`. This controls which type of prediction is done. Mostly used to allow for both hard and soft classification predictions
- adds `pred_names` attribute to orbital objects. to be tested better with https://github.com/tidymodels/orbital/issues/68
- makes `logistic_reg()` models give soft predictions