### PR TITLE
refactor out set_pred_names()

### DIFF
--- a/R/model-glm.R
+++ b/R/model-glm.R
@@ -19,7 +19,7 @@ orbital.glm <- function(
 		if ("class" %in% type) {
 			res <- c(
 				res,
-				glue::glue(
+				orbital_tmp_class_name = glue::glue(
 					"dplyr::case_when({eq} < 0.5 ~ {levels[1]}, .default = {levels[2]})"
 				)
 			)
@@ -27,8 +27,8 @@ orbital.glm <- function(
 		if ("prob" %in% type) {
 			res <- c(
 				res,
-				glue::glue("1 - ({eq})"),
-				glue::glue("{eq}")
+				orbital_tmp_prob_name1 = glue::glue("1 - ({eq})"),
+				orbital_tmp_prob_name2 = glue::glue("{eq}")
 			)
 		}
 	} else if (mode == "regression") {

--- a/R/model-xgboost.R
+++ b/R/model-xgboost.R
@@ -42,14 +42,17 @@ xgboost_multisoft <- function(x, type, lvl) {
 	if ("class" %in% type) {
 		res <- c(
 			res,
-			".pred_class" = softmax(lvl)
+			orbital_tmp_class_name = softmax(lvl)
 		)
 	}
 	if ("prob" %in% type) {
+		eqs <- glue::glue("exp({lvl}) / norm")
+		names(eqs) <- paste0("orbital_tmp_prob_name", seq_along(lvl))
+
 		res <- c(
 			res,
 			"norm" = glue::glue_collapse(glue::glue("exp({lvl})"), sep = " + "),
-			stats::setNames(glue::glue("exp({lvl}) / norm"), NA)
+			eqs
 		)
 	}
 	res
@@ -80,7 +83,7 @@ xgboost_logistic <- function(x, type, lvl) {
 
 		res <- c(
 			res,
-			.pred_class = glue::glue(
+			orbital_tmp_class_name = glue::glue(
 				"dplyr::case_when({eq} > 0.5 ~ {levels[1]}, .default = {levels[2]})"
 			)
 		)
@@ -88,8 +91,8 @@ xgboost_logistic <- function(x, type, lvl) {
 	if ("prob" %in% type) {
 		res <- c(
 			res,
-			glue::glue("{eq}"),
-			glue::glue("1 - ({eq})")
+			orbital_tmp_prob_name1 = glue::glue("{eq}"),
+			orbital_tmp_prob_name2 = glue::glue("1 - ({eq})")
 		)
 	}
 	res


### PR DESCRIPTION
this refactors out some very xgboost specific code we had before.

Now the workflow is:

- model specific `orbital()` classification model uses `orbital_tmp_class_name` or `orbital_tmp_prob_name*` as names. and `set_pred_names()` will apply them as appropriate 