### PR TITLE
filter out 0 terms in pca_helper()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # orbital (development version)
 
+* `step_pca_sparse()` no longer generate code with terms with 0 in them. (#51)
+
 # orbital 0.3.0
 
 * `orbital()` has gained `type` argument to change prediction type. (#66)

--- a/R/recipes-utils.R
+++ b/R/recipes-utils.R
@@ -43,7 +43,11 @@ pca_helper <- function(rot, prefix, all_vars) {
 
   out <- character(length(all_vars))
   for (i in seq_along(all_vars)) {
-    out[i] <- paste(glue::glue("{row_nms} * {rot[, i]}"), collapse = " + ")
+    non_zero <- rot[, i] != 0
+    out[i] <- paste(
+      glue::glue("{row_nms[non_zero]} * {rot[, i][non_zero]}"),
+      collapse = " + "
+    )
   }
 
   names(out) <- all_vars

--- a/tests/testthat/test-step_pca_sparse.R
+++ b/tests/testthat/test-step_pca_sparse.R
@@ -58,6 +58,26 @@ test_that("step_pca_sparse only calculates what is sufficient", {
   )
 })
 
+test_that("step_pca_sparse removes 0 multiples", {
+  skip_if_not_installed("recipes")
+  skip_if_not_installed("embed")
+
+  mtcars <- dplyr::as_tibble(mtcars)
+  mtcars$hp <- NULL
+
+  suppressWarnings(
+    rec <- recipes::recipe(mpg ~ ., data = mtcars) |>
+      embed::step_pca_sparse(recipes::all_predictors()) |>
+      recipes::prep()
+  )
+
+  exp <- recipes::bake(rec, new_data = mtcars)
+
+  expect_true(
+    all(!grepl("* 0 ", orbital(rec)))
+  )
+})
+
 test_that("step_pca_sparse works with empty selections", {
   skip_if_not_installed("recipes")
   skip_if_not_installed("embed")


### PR DESCRIPTION
To close $51

``` r
library(orbital)
library(recipes)
library(embed)
library(dplyr)


mtcars <- as_tibble(mtcars)

rec <- recipe(mpg ~ ., data = mtcars) %>%
  step_pca_sparse(all_predictors(), predictor_prop = 0.2) %>%
  prep()
#> Warning in irlba(x, k, scale = scale., center = center, ...): You're computing
#> too large a percentage of total singular values, use a standard svd instead.

rec |>
  orbital() |>
  print(truncate = FALSE)
#> 
#> ── orbital Object ──────────────────────────────────────────────────────────────
#> • PC1 = disp * 0.8646427 + hp * 0.5023873
#> • PC2 = disp * 0.4852534 + hp * -0.8743736
#> • PC3 = drat * -0.01086373 + qsec * -0.999941
#> • PC4 = wt * -0.03797671 + carb * -0.9992786
#> • PC5 = cyl * 0.992033 + vs * -0.1259784
#> ────────────────────────────────────────────────────────────────────────────────
#> 5 equations in total.
```

<sup>Created on 2025-07-02 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>