### PR TITLE
Guard adjust_numeric_range tests on probably

### DIFF
--- a/tests/testthat/test-adjust_numeric_range.R
+++ b/tests/testthat/test-adjust_numeric_range.R
@@ -1,5 +1,6 @@
 test_that("adjust_predictions_custom works - defaults", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
 
   tlr <- tailor::tailor() |>
     tailor::adjust_numeric_range()
@@ -23,6 +24,7 @@ test_that("adjust_predictions_custom works - defaults", {
 
 test_that("adjust_predictions_custom works - lower_limit", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
 
   tlr <- tailor::tailor() |>
     tailor::adjust_numeric_range(lower_limit = 15)
@@ -46,6 +48,7 @@ test_that("adjust_predictions_custom works - lower_limit", {
 
 test_that("adjust_predictions_custom works - upper_limit", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
 
   tlr <- tailor::tailor() |>
     tailor::adjust_numeric_range(upper_limit = 25)
@@ -69,6 +72,7 @@ test_that("adjust_predictions_custom works - upper_limit", {
 
 test_that("adjust_predictions_custom works - both", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
 
   tlr <- tailor::tailor() |>
     tailor::adjust_numeric_range(lower_limit = 15, upper_limit = 25)
@@ -92,6 +96,7 @@ test_that("adjust_predictions_custom works - both", {
 
 test_that("spark - adjust_predictions_custom works", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
   skip_if_not_installed("sparklyr")
   skip_if(is.na(testthat_spark_env_version()))
 
@@ -118,6 +123,7 @@ test_that("spark - adjust_predictions_custom works", {
 
 test_that("SQLite - adjust_predictions_custom works", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
   skip_if_not_installed("DBI")
   skip_if_not_installed("RSQLite")
   skip_on_cran()
@@ -146,6 +152,7 @@ test_that("SQLite - adjust_predictions_custom works", {
 
 test_that("duckdb - adjust_predictions_custom works", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
   skip_if_not_installed("DBI")
   skip_if_not_installed("duckdb")
 
@@ -173,6 +180,7 @@ test_that("duckdb - adjust_predictions_custom works", {
 
 test_that("arrow - adjust_predictions_custom works", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
   skip_if_not_installed("arrow")
 
   tlr <- tailor::tailor() |>
@@ -197,6 +205,7 @@ test_that("arrow - adjust_predictions_custom works", {
 
 test_that("estimate_adj_chars works for numeric_range", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
 
   tlr <- tailor::tailor() |>
     tailor::adjust_numeric_range(lower_limit = 15, upper_limit = 25)
@@ -215,6 +224,7 @@ test_that("estimate_adj_chars works for numeric_range", {
 
 test_that("estimate_adj_chars works for numeric_range with no limits", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
 
   tlr <- tailor::tailor() |>
     tailor::adjust_numeric_range()
@@ -232,6 +242,7 @@ test_that("estimate_adj_chars works for numeric_range with no limits", {
 
 test_that("estimate_orbital_size works for tailor", {
   skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
 
   tlr <- tailor::tailor() |>
     tailor::adjust_numeric_range(lower_limit = 15, upper_limit = 25)


### PR DESCRIPTION
Found while investigating CI on #150. This is unrelated to that PR and pre-existing on `main`.

## Problem

`tests/testthat/test-adjust_numeric_range.R` has 11 tests that call `tailor::adjust_numeric_range()`, but each only guards on `skip_if_not_installed("tailor")`.

All four probably-backed tailor adjustments (`adjust_numeric_range`, `adjust_equivocal_zone`, `adjust_numeric_calibration`, `adjust_probability_calibration`) begin with a call to `tailor:::validate_probably_available()`:

```r
if (!requireNamespace("probably", quietly = TRUE)) {
  cli_abort("The {.pkg probably} package must be available to use this adjustment.")
}
```

So when probably cannot be loaded, these tests **error** instead of skipping. On the macOS runner that produced 10 errors of the form:

```
Error in `tailor::adjust_numeric_range(tailor::tailor(), lower_limit = 15)`:
  The probably package must be available to use this adjustment.
```

## Fix

Add `skip_if_not_installed("probably")` alongside the existing tailor guard in all 11 tests. `test-adjust_equivocal_zone.R` and `test-adjust_probability_threshold.R` already do this, so this file was simply the odd one out.

## Note on the root cause

probably 1.2.0 *is* installed successfully on the runner, and all of its imports (butcher, furrr, ggplot2 4.0.3, tune, workflows, yardstick) are present, yet `requireNamespace()` still returns `FALSE`. Because that call uses `quietly = TRUE`, the underlying load error is swallowed and does not reach the log, so I could not determine why it fails to load. The same version combination loads fine locally.

That underlying load problem is worth chasing separately. Either way this guard is correct: probably is a `Suggests`, and tests depending on it should skip rather than error when it is unusable.

## Verification

- `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 17 ]` locally, so the new guards do not cause spurious skipping where probably is available.
- Diff is 11 added lines and nothing else.