### PR TITLE
Retry Spark download so the cache can be seeded

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -42,14 +42,32 @@ jobs:
         with:
           path: /home/runner/spark/spark-3.3.4-bin-hadoop3
           key: sparklyr-spark-3.3.4-bin-hadoop3-3
+          restore-keys: |
+            sparklyr-spark-3.3.4-bin-hadoop3-
 
+      # See the note in spark-tests.yaml: archive.apache.org rate-limits
+      # GitHub Actions runners, so retry with backoff.
       - name: Install Spark (via sparklyr)
         if: steps.cache-spark.outputs.cache-hit != 'true'
         run: |
-          sparklyr::spark_install(
-            version = "3.3.4",
-            hadoop_version = "3"
-          )
+          attempts <- 5
+          for (i in seq_len(attempts)) {
+            ok <- tryCatch(
+              {
+                sparklyr::spark_install(version = "3.3.4", hadoop_version = "3")
+                TRUE
+              },
+              error = function(cnd) {
+                message("Attempt ", i, " of ", attempts, " failed: ", conditionMessage(cnd))
+                FALSE
+              }
+            )
+            if (ok) break
+            if (i < attempts) Sys.sleep(i * 20)
+          }
+          if (!ok) {
+            stop("Could not install Spark after ", attempts, " attempts.")
+          }
         shell: Rscript {0}
 
       - name: Build site

--- a/.github/workflows/spark-tests.yaml
+++ b/.github/workflows/spark-tests.yaml
@@ -49,14 +49,37 @@ jobs:
         with:
           path: /home/runner/spark/spark-${{ matrix.config.spark }}-bin-hadoop${{ matrix.config.hadoop }}
           key: sparklyr-spark-${{ matrix.config.spark }}-bin-hadoop${{ matrix.config.hadoop }}-3
+          restore-keys: |
+            sparklyr-spark-${{ matrix.config.spark }}-bin-hadoop${{ matrix.config.hadoop }}-
 
+      # archive.apache.org rate-limits GitHub Actions runners, so a single
+      # attempt fails intermittently. Retry with backoff: the download only has
+      # to succeed once for the cache above to be seeded, after which this step
+      # is skipped entirely.
       - name: Install Spark (via sparklyr)
         if: steps.cache-spark.outputs.cache-hit != 'true'
         run: |
-          sparklyr::spark_install(
-            version = Sys.getenv("SPARK_VERSION"),
-            hadoop_version = Sys.getenv("HADOOP_VERSION")
-          )
+          attempts <- 5
+          for (i in seq_len(attempts)) {
+            ok <- tryCatch(
+              {
+                sparklyr::spark_install(
+                  version = Sys.getenv("SPARK_VERSION"),
+                  hadoop_version = Sys.getenv("HADOOP_VERSION")
+                )
+                TRUE
+              },
+              error = function(cnd) {
+                message("Attempt ", i, " of ", attempts, " failed: ", conditionMessage(cnd))
+                FALSE
+              }
+            )
+            if (ok) break
+            if (i < attempts) Sys.sleep(i * 20)
+          }
+          if (!ok) {
+            stop("Could not install Spark after ", attempts, " attempts.")
+          }
         shell: Rscript {0}
 
       - name: Cache Livy


### PR DESCRIPTION
Answers "can we cache the Spark install?" — the cache was already configured, but it could never work. This makes it work.

## Why caching alone was not enough

`spark-tests.yaml` and `pkgdown.yaml` both already had a `Cache Spark` step with a sensible path and key. But querying the repo's caches shows **zero** Spark or Scala entries; all 17 are R-package caches from `setup-r-dependencies`.

The reason is a deadlock:

1. `actions/cache` only saves its cache when the job **succeeds**.
2. The job fails at `Install Spark (via sparklyr)`, because archive.apache.org rate-limits GitHub Actions runners.
3. So the cache is never written, and the next run downloads again, and fails again.

The cache can never be seeded while the download is flaky, so no amount of cache tuning fixes it. The download has to succeed once.

## Change

Retry `sparklyr::spark_install()` up to 5 times with linear backoff (20s, 40s, 60s, 80s; ~200s worst case). Once it succeeds, the cache is written and the step is skipped on every subsequent run, so the retry cost is paid at most once per cache lifetime.

Also added `restore-keys` so a cache stored under an older key suffix is reused rather than discarded. The current key ends in a hand-bumped `-3`.

Applied to both workflows, since `pkgdown.yaml` installs Spark too and was failing for exactly the same reason.

## Verification

- Both YAML files parse.
- Retry logic tested against a stub on both paths: recovers when the call fails twice then succeeds, and still evaluates to `FALSE` (so `stop()` fires) when every attempt fails. It cannot silently continue with a broken install, since the loop only breaks on success.

## Note on the base branch

Based on `guard-probably-in-numeric-range-tests` (#151) rather than `main`. Basing it on main would have reintroduced the probably errors that #151 fixes, making this PR's CI red for an unrelated reason. Retarget to main once #151 merges.

## Not fixed here

`windows-latest (oldrel-4)` fails separately with `function 'cholmod_factor_ldetA' not provided by package 'Matrix'`, an lme4/Matrix ABI mismatch on R 4.2 affecting the `step_lencode_*` tests. Pre-existing on main and needs a different fix (source-installing lme4 on oldrel, or dropping that matrix entry).