### PR TITLE
Build lme4 from source on windows oldrel-4

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -27,7 +27,14 @@ jobs:
 
           - {os: windows-latest, r: 'release'}
           # use 4.0 or 4.1 to check with rtools40's older compiler
-          - {os: windows-latest, r: 'oldrel-4'}
+          #
+          # The lme4 binary for this R version was built against a newer Matrix
+          # than the one resolved here, so it aborts on load with "lme4 was
+          # built with Matrix ABI version 1 / Current Matrix ABI version is 0",
+          # taking the step_lencode_* tests with it. Building lme4 from source
+          # links it against the Matrix actually installed, which is what lme4's
+          # own error message recommends.
+          - {os: windows-latest, r: 'oldrel-4', extra: ', lme4?source'}
 
           - {os: ubuntu-latest,  r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,  r: 'release'}
@@ -52,7 +59,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, xgboost=?ignore-before-r=4.3.0
+          extra-packages: any::rcmdcheck, xgboost=?ignore-before-r=4.3.0${{ matrix.config.extra }}
           needs: check
 
       - name: Install catboost


### PR DESCRIPTION
Fixes the last remaining CI failure. Pre-existing on `main`, unrelated to the tidypredict backend work.

## Cause

`windows-latest (oldrel-4)` fails with 10 errors, all in `step_lencode_bayes` and `step_lencode_mixed`. The root cause is stated plainly in the log:

```
lme4 was built with Matrix ABI version 1
Current Matrix ABI version is 0
Please re-install lme4 from source or restore original 'Matrix' package
```

The prebuilt lme4 binary for this R version was compiled against a newer Matrix than the one resolved on the runner. lme4 detects the mismatch in `check_dep_version()` at load time and aborts, surfacing as `function 'cholmod_factor_ldetA' not provided by package 'Matrix'` (22 occurrences). Nothing in orbital influences this.

## Change

Install lme4 from source on that one job, which links it against the Matrix actually present. This is exactly the remedy lme4's own error message recommends.

Scoped via a per-config `extra` field so only the oldrel-4 entry is affected:

```
windows-latest   oldrel-4   -> any::rcmdcheck, xgboost=?ignore-before-r=4.3.0, lme4?source
macos-latest     release    -> any::rcmdcheck, xgboost=?ignore-before-r=4.3.0
ubuntu-latest    devel      -> any::rcmdcheck, xgboost=?ignore-before-r=4.3.0
...
```

The other seven jobs keep a byte-identical `extra-packages` value and do not pay for compiling lme4. The leading comma lives inside the `extra` value, so configs without it expand to nothing rather than leaving a trailing comma.

## Verification

- Confirmed `lme4?source` is valid pak syntax and resolves to a source package (`pak::pkg_download("lme4?source")` returns `platform: source`).
- Note the `lme4=?source` spelling, matching the existing `xgboost=?ignore-before-r=...` line, does **not** work: it appears to parse as name `lme4` with ref `?source` and hangs. Used the plain `lme4?source` form.
- Matrix expansion simulated for all eight configs; only oldrel-4 differs.

## Note on the base branch

Based on `retry-spark-download` (#152), which is itself based on #151, to avoid reintroducing failures those PRs fix. Retarget down the stack as each merges.