### PR TITLE
Fix number corruption in pretty_print()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-* `print()` no longer corrupts numbers when rounding them for display. Numbers such as `6.75044994983228` and `-0.0901719835820594` were printed as `6.750.5` and `-017198`. Only the printed output was affected; the expressions themselves were always correct. (#154)
+* `print()` no longer corrupts numbers when rounding them for display. Numbers such as `6.75044994983228` and `-0.0901719835820594` were printed as `6.750.5` and `-017198`. Only the printed output was affected; the expressions themselves were always correct. (#155)
 
 # orbital 0.5.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # orbital (development version)
 
+## Bug fixes
+
+* `print()` no longer corrupts numbers when rounding them for display. Numbers such as `6.75044994983228` and `-0.0901719835820594` were printed as `6.750.5` and `-017198`. Only the printed output was affected; the expressions themselves were always correct. (#154)
+
 # orbital 0.5.1
 
 ## Improvements

--- a/R/orbital.R
+++ b/R/orbital.R
@@ -116,16 +116,17 @@ print.orbital_class <- function(x, ..., digits = 7, truncate = TRUE) {
   invisible(NULL)
 }
 
+# Rounds every numeric literal in `x` for display. Uses `regmatches<-` rather
+# than a `sub()` loop so that each match is replaced in place: `sub()` would
+# treat the matched number as a regex (making "." a wildcard) and would recycle
+# over every element of `x`, both of which corrupted the output.
 pretty_print <- function(x, digits = 7) {
-  old_values <- regmatches(x, gregexpr("[0-9]+\\.?[0-9]+", x))
-  new_values <- lapply(old_values, function(x) signif(as.numeric(x), digits))
+  matches <- gregexpr("[0-9]+\\.?[0-9]+", x)
 
-  old_values <- unlist(old_values, use.names = FALSE)
-  new_values <- unlist(new_values, use.names = FALSE)
-
-  for (i in seq_along(old_values)) {
-    x <- sub(old_values[i], new_values[i], x)
-  }
+  regmatches(x, matches) <- lapply(
+    regmatches(x, matches),
+    function(value) as.character(signif(as.numeric(value), digits))
+  )
 
   x
 }

--- a/tests/testthat/_snaps/sql.md
+++ b/tests/testthat/_snaps/sql.md
@@ -21,10 +21,10 @@
       orbital_sql(obj, con)
     Output
       <SQL> CASE
-      WHEN ((1 / (1 + EXP(-((6.750.5 + ("disp" * -0.003776033)) + ("hp" * -0.04870484))))) > 0.5) THEN '1'
+      WHEN ((1 / (1 + EXP(-((6.75045 + ("disp" * -0.003776033)) + ("hp" * -0.04870484))))) > 0.5) THEN '1'
       ELSE '0'
       END AS .pred_class
-      <SQL> 1 - (1 / (1 + EXP(-((6.750.5 + ("disp" * -0.003776033)) + ("hp" * -0.04870484))))) AS .pred_0
+      <SQL> 1 - (1 / (1 + EXP(-((6.75045 + ("disp" * -0.003776033)) + ("hp" * -0.04870484))))) AS .pred_0
       <SQL> 1 - ".pred_0" AS .pred_1
 
 # sql works for glmnet multiclass
@@ -51,10 +51,10 @@
       orbital_sql(obj, con)
     Output
       <SQL> CASE
-      WHEN ((1 - 1 / (1 + EXP((1.863314 + (CASE WHEN ("hp" > 105) THEN ("hp" - 105) WHEN NOT ("hp" > 105) THEN 0 END * -017198)) + (CASE WHEN ("hp" > 175) THEN ("hp" - 175) WHEN NOT ("hp" > 175) THEN 0 END * -2.746445)))) > 0.5) THEN '1'
+      WHEN ((1 - 1 / (1 + EXP((1.863314 + (CASE WHEN ("hp" > 105) THEN ("hp" - 105) WHEN NOT ("hp" > 105) THEN 0 END * -0.09017198)) + (CASE WHEN ("hp" > 175) THEN ("hp" - 175) WHEN NOT ("hp" > 175) THEN 0 END * -2.746445)))) > 0.5) THEN '1'
       ELSE '0'
       END AS .pred_class
-      <SQL> 1 - (1 - 1 / (1 + EXP((1.863314 + (CASE WHEN ("hp" > 105) THEN ("hp" - 105) WHEN NOT ("hp" > 105) THEN 0 END * -017198)) + (CASE WHEN ("hp" > 175) THEN ("hp" - 175) WHEN NOT ("hp" > 175) THEN 0 END * -2.746445)))) AS .pred_0
+      <SQL> 1 - (1 - 1 / (1 + EXP((1.863314 + (CASE WHEN ("hp" > 105) THEN ("hp" - 105) WHEN NOT ("hp" > 105) THEN 0 END * -0.09017198)) + (CASE WHEN ("hp" > 175) THEN ("hp" - 175) WHEN NOT ("hp" > 175) THEN 0 END * -2.746445)))) AS .pred_0
       <SQL> 1 - ".pred_0" AS .pred_1
 
 # sql works for randomForest classification

--- a/tests/testthat/test-orbital.R
+++ b/tests/testthat/test-orbital.R
@@ -169,6 +169,27 @@ test_that("orbital printing works", {
   )
 })
 
+test_that("pretty_print rounds each number in place", {
+  expect_identical(
+    pretty_print("(6.75044994983228 + (disp * -0.00377603284098302))"),
+    "(6.75045 + (disp * -0.003776033))"
+  )
+
+  # A regex-matched number must not be re-substituted by a later match: "0.5"
+  # as a regex once turned "6.75045" into "6.750.5", and "0.0" applied twice
+  # turned "0.09017198" into "017198".
+  expect_identical(
+    pretty_print("0.0901719835820594 END * 0.5 + 0.0"),
+    "0.09017198 END * 0.5 + 0"
+  )
+
+  # Each element is rounded using its own matches, not the whole vector's.
+  expect_identical(
+    pretty_print(c("a 1.55555555 b", "c 2.66666666 d"), digits = 3),
+    c("a 1.56 b", "c 2.67 d")
+  )
+})
+
 test_that("prefix argument works", {
   skip_if_not_installed("recipes")
   skip_if_not_installed("parsnip")


### PR DESCRIPTION
The plan for the new tidypredict backends flagged two malformed numeric literals in the SQL snapshots, `6.750.5` (glmnet) and `-017198` (earth), as a suspected coefficient-formatting bug that would fail to parse on a real engine.

**That diagnosis was wrong in an important way, and the good news is the better one:** the generated SQL was never affected. The raw expressions are `6.75044994983228` and `-0.0901719835820594`, both perfectly valid. The corruption came from `pretty_print()`, which is called from `print.orbital_class()` and as a snapshot `transform` in `test-sql.R` / `test-dt.R`, but never in the SQL generation path. So no user has ever been handed invalid SQL from this. What they could get is garbled numbers when printing an orbital object, which is still a real user-facing bug, just a display one.

## Two compounding bugs

`pretty_print()` rounded numbers with a loop of `sub()` calls.

**1. The matched number was used as a regex.** `.` is a wildcard, so once `6.75044994983228` had been correctly rounded to `6.75045`, a later substitution of `0.5` matched the `045` inside it:

```r
sub("0.5", "0.5", "6.75045")
#> "6.750.5"
```

**2. `x` is a vector, but the match lists were flattened.** `unlist()` collapsed the per-element matches before the loop, so each `sub()` ran against *every* element of `x` rather than the one its match came from. Applying `0.0` twice this way:

```r
sub("0.0", "0", sub("0.0", "0", "0.09017198"))
#> "017198"
```

Both reproduce the snapshot values exactly.

## Fix

Use `regmatches<-`, which replaces each match in place, per element, and never reinterprets the matched text as a pattern.

## Verification

Full suite with Spark enabled: `FAIL 0 | WARN 4 | SKIP 10 | PASS 1066`, up from 1064.

The only snapshot movement in the whole suite was the two corrupted numbers becoming their correct `signif(x, 7)` values, `6.75045` and `-0.09017198`. Nothing else changed, which is the review criterion here: a fix to a rounding routine used as a snapshot transform could easily have shifted unrelated values, and it did not.