### PR TITLE
Add multiclass_from_probs() and binary_from_decision()

### DIFF
--- a/R/classification-helpers.R
+++ b/R/classification-helpers.R
@@ -117,6 +117,55 @@ multiclass_from_prob_avg <- function(prob_sum_eqs, type, lvl, n_trees) {
   res
 }
 
+# Multiclass from probabilities that are already normalized
+# Unlike multiclass_from_prob_avg(), nothing is divided: the incoming
+# expressions already sum to one across levels, so the probability sentinels
+# only need to reference the per-level columns.
+multiclass_from_probs <- function(prob_eqs, type, lvl) {
+  res <- stats::setNames(prob_eqs, lvl)
+  lvl_bt <- backtick(lvl)
+
+  if ("prob" %in% type) {
+    prob_refs <- stats::setNames(
+      lvl_bt,
+      paste0("orbital_tmp_prob_name", seq_along(lvl))
+    )
+    res <- c(res, prob_refs)
+  }
+  if ("class" %in% type) {
+    res <- c(res, orbital_tmp_class_name = softmax_class(lvl))
+  }
+  res
+}
+
+# Binary classification from a decision value rather than a probability, as
+# produced by LiblineaR SVMs. The sign of the decision value picks the class, so
+# the cut is at 0 rather than 0.5. As with binary_from_prob(), a positive value
+# means the second level.
+#
+# No probability is emitted: a decision value is uncalibrated, and putting it
+# through a logistic would invent a calibration the model does not have.
+binary_from_decision <- function(eq, type, lvl, call = rlang::caller_env()) {
+  if ("prob" %in% type) {
+    cli::cli_abort(
+      c(
+        "{.val prob} predictions are not available for this model.",
+        i = "It produces an uncalibrated decision value rather than a
+             probability.",
+        i = "Use {.code type = \"class\"} instead."
+      ),
+      call = call
+    )
+  }
+
+  levels <- glue::double_quote(lvl)
+  c(
+    orbital_tmp_class_name = glue::glue(
+      "dplyr::case_when({eq} > 0 ~ {levels[2]}, .default = {levels[1]})"
+    )
+  )
+}
+
 # Collapse stump trees (single-leaf) into a constant value
 # Used by xgboost, lightgbm, catboost for multiclass
 # Stumps are case_when(.default = value) expressions where the value is at [[2]]

--- a/tests/testthat/_snaps/classification-helpers.md
+++ b/tests/testthat/_snaps/classification-helpers.md
@@ -1,0 +1,10 @@
+# binary_from_decision refuses to invent a probability
+
+    Code
+      orbital:::binary_from_decision("d", c("class", "prob"), c("no", "yes"))
+    Condition
+      Error:
+      ! "prob" predictions are not available for this model.
+      i It produces an uncalibrated decision value rather than a probability.
+      i Use `type = "class"` instead.
+

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -1,3 +1,19 @@
+## Evaluate orbital equations against a data frame.
+##
+## Equations are evaluated in order, each one able to see the columns the
+## earlier ones added, which is how orbital's generated code is meant to run.
+## Used to check that helpers compute the right values, not just that their
+## expression text is stable.
+eval_orbital_eqs <- function(eqs, data) {
+  for (name in names(eqs)) {
+    data[[name]] <- rlang::eval_tidy(
+      rlang::parse_expr(eqs[[name]]),
+      data = data
+    )
+  }
+  data
+}
+
 ## For sparklyr testing
 
 testthat_tbl <- function(name, data = NULL, repartition = 0L) {

--- a/tests/testthat/test-classification-helpers.R
+++ b/tests/testthat/test-classification-helpers.R
@@ -168,6 +168,106 @@ test_that("multiclass_from_prob_avg returns correct structure for prob only", {
   )
 })
 
+test_that("multiclass_from_probs references levels without dividing", {
+  result <- orbital:::multiclass_from_probs(
+    c("0.5", "0.3", "0.2"),
+    c("class", "prob"),
+    c("a", "b", "c")
+  )
+
+  expect_identical(
+    result[c("a", "b", "c")],
+    c(a = "0.5", b = "0.3", c = "0.2")
+  )
+  expect_identical(
+    result[paste0("orbital_tmp_prob_name", 1:3)],
+    c(
+      orbital_tmp_prob_name1 = "`a`",
+      orbital_tmp_prob_name2 = "`b`",
+      orbital_tmp_prob_name3 = "`c`"
+    )
+  )
+  expect_named(result[4], "orbital_tmp_prob_name1")
+})
+
+test_that("multiclass_from_probs omits sentinels not asked for", {
+  expect_named(
+    orbital:::multiclass_from_probs("1", "class", "a"),
+    c("a", "orbital_tmp_class_name")
+  )
+  expect_named(
+    orbital:::multiclass_from_probs("1", "prob", "a"),
+    c("a", "orbital_tmp_prob_name1")
+  )
+})
+
+test_that("multiclass_from_probs evaluates to the same values as R", {
+  # Value-level check: the expression text being stable says nothing about it
+  # computing the right thing.
+  data <- data.frame(
+    p1 = c(0.7, 0.1, 0.2, 1 / 3),
+    p2 = c(0.2, 0.8, 0.2, 1 / 3),
+    p3 = c(0.1, 0.1, 0.6, 1 / 3)
+  )
+  lvl <- c("a", "b", "c")
+
+  eqs <- orbital:::multiclass_from_probs(
+    c("p1", "p2", "p3"),
+    c("class", "prob"),
+    lvl
+  )
+  res <- eval_orbital_eqs(eqs, data)
+
+  probs <- as.matrix(data)
+  expect_equal(
+    unname(as.matrix(res[paste0("orbital_tmp_prob_name", 1:3)])),
+    unname(probs)
+  )
+
+  # Ties go to the earlier level, so row 4 is "a".
+  expect_identical(
+    res$orbital_tmp_class_name,
+    c("a", "b", "c", "a")
+  )
+  expect_identical(
+    res$orbital_tmp_class_name,
+    lvl[apply(probs, 1, which.max)]
+  )
+})
+
+test_that("binary_from_decision cuts at zero, not 0.5", {
+  result <- orbital:::binary_from_decision("d", "class", c("no", "yes"))
+
+  expect_identical(
+    result,
+    c(
+      orbital_tmp_class_name = 'dplyr::case_when(d > 0 ~ "yes", .default = "no")'
+    )
+  )
+})
+
+test_that("binary_from_decision evaluates to the sign of the decision value", {
+  data <- data.frame(d = c(-2, -0.001, 0, 0.001, 2))
+
+  res <- eval_orbital_eqs(
+    orbital:::binary_from_decision("d", "class", c("no", "yes")),
+    data
+  )
+
+  # A decision value of exactly 0 falls to the first level.
+  expect_identical(
+    res$orbital_tmp_class_name,
+    c("no", "no", "no", "yes", "yes")
+  )
+})
+
+test_that("binary_from_decision refuses to invent a probability", {
+  expect_snapshot(
+    error = TRUE,
+    orbital:::binary_from_decision("d", c("class", "prob"), c("no", "yes"))
+  )
+})
+
 test_that("sum_tree_expressions sums and deparses correctly", {
   tree1 <- rlang::expr(case_when(x > 1 ~ 0.5, .default = 0.3))
   tree2 <- rlang::expr(case_when(x > 2 ~ 0.6, .default = 0.4))


### PR DESCRIPTION
O2 / phase 3 of the new-backends plan, and the leverage point: these two shapes cover roughly 14 of the ~25 backends being added.

## The adapters

**`multiclass_from_probs()`** takes probability expressions that already sum to one across levels. It is `multiclass_from_prob_avg()` without the division by tree count, so the probability sentinels only reference the per-level columns.

**`binary_from_decision()`** takes a decision value rather than a probability, as LiblineaR SVMs produce, and cuts at 0 instead of 0.5. It **refuses `type = "prob"`** rather than pushing the decision value through a logistic. A decision value is uncalibrated, and a logistic would invent a calibration the model does not have, producing numbers that look like probabilities and are not. Refusing is the honest option, and it matches the interim-refusal stance from #156.

## Deliberately not wired up

Neither adapter is called from `orbital.model_fit()` yet. Routing was specified to key on the `output` / `levels` / `normalized` metadata from tidypredict, which **does not exist yet** (phase 1b / T2 in the plan). The alternative, sniffing the result shape, is available but I would rather not add a heuristic that has to be removed a release later.

So this PR is the adapters plus tests, reviewable in isolation, and the routing lands with the PR that consumes the metadata. That also keeps it revertable on its own.

## Tests check values, not just text

A snapshot proves the expression text is stable, not that it computes the right answer — a distinction that already cost time earlier in this project. New `eval_orbital_eqs()` test helper evaluates generated equations in order against a data frame, which is how orbital's output actually runs.

That covers two behaviours no snapshot would catch:

- **argmax ties resolve to the earlier level.** Three equal probabilities give `"a"`, matching `softmax_class()`'s `>=` and `which.max()`.
- **a decision value of exactly 0 falls to the first level**, since the cut is `> 0`.

Full suite: `FAIL 0 | PASS 1083`, up from 1072.

No NEWS bullet: nothing is user-facing until the routing lands.