### PR TITLE
Route the tidypredict fallback through the classification adapters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,9 @@ Imports:
 Suggests:
     arrow,
     bonsai,
+    C50,
     DBI,
+    discrim,
     dbplyr,
     dtplyr,
     duckdb,
@@ -36,6 +38,7 @@ Suggests:
     jsonlite,
     kknn,
     knitr,
+    LiblineaR,
     lightgbm,
     modeldata,
     parsnip,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # orbital (development version)
 
+## Improvements
+
+* `orbital()` now supports classification models that reach the tidypredict fallback, rather than refusing them. This covers multiclass probability models such as `MASS::lda()`, models returning an uncalibrated decision value such as `LiblineaR` SVMs, and models predicting a class label directly such as `C50::C5.0()`. (#159)
+
+* `orbital()` refuses `type = "prob"` for models that have no probability to give, rather than fabricating one. A decision value is uncalibrated, so putting it through a logistic would invent a calibration the model does not have. (#159)
+
 ## Bug fixes
 
 * Binary `earth()` classification models now generate `1 / (1 + exp(-x))` rather than the equivalent `1 - 1 / (1 + exp(x))`. Predictions are unchanged. (#158)

--- a/R/fallback-routing.R
+++ b/R/fallback-routing.R
@@ -1,0 +1,146 @@
+# Adapts a tidypredict result into the sentinel-named equations that
+# `set_pred_names()` expects.
+#
+# orbital's own methods attach those sentinels themselves; a tidypredict result
+# carries none, so without this the prediction columns come out named after
+# tidypredict's internals.
+#
+# What shape the result has cannot be recovered from the result itself, which is
+# why it is asked for rather than sniffed. `LiblineaR` returns a single
+# expression both for a probability and for an uncalibrated decision value, and
+# cutting a decision value at 0.5 would give silently wrong classes for every
+# row whose value falls between 0 and 0.5.
+route_fallback <- function(res, x, mode, type, call = rlang::caller_env()) {
+  if (mode != "classification") {
+    return(res)
+  }
+
+  output <- tryCatch(
+    tidypredict_output_type(x$fit),
+    # A model tidypredict can fit but cannot describe. Refusing keeps the
+    # pre-routing behaviour rather than guessing at the shape.
+    tidypredict_no_metadata = function(cnd) abort_unsupported_output(x, call)
+  )
+
+  switch(
+    output,
+    prob = route_prob(res, x, type, call),
+    decision = binary_from_decision(
+      deparse_eq(res, x, call),
+      type,
+      x$lvl,
+      call = call
+    ),
+    class = route_class(res, x, type, call),
+    # A classification model whose fit is a plain number is `binary:hinge` and
+    # friends; that is reported as "class", so reaching here means the mode and
+    # the model disagree.
+    numeric = abort_unsupported_output(x, call)
+  )
+}
+
+# Wrapped rather than called through `tidypredict::` so that tests can mock it
+# without reaching into another package's namespace. See `?local_mocked_bindings`.
+tidypredict_output_type <- function(x) {
+  tidypredict::tidypredict_output_type(x)
+}
+
+route_prob <- function(res, x, type, call) {
+  lvl <- x$lvl
+
+  if (is.language(res)) {
+    # Binary: one expression giving the probability of the second level.
+    return(binary_from_prob(deparse1(res, control = "digits17"), type, lvl))
+  }
+
+  if (isFALSE(tidypredict::tidypredict_normalized(x$fit))) {
+    cli::cli_abort(
+      c(
+        "Per-level values for this model do not sum to one.",
+        i = "orbital does not yet normalize them."
+      ),
+      call = call
+    )
+  }
+
+  prob_eqs <- order_prob_eqs(deparse_eqs(res), x, lvl, call)
+
+  multiclass_from_probs(prob_eqs, type, lvl)
+}
+
+# tidypredict returns the per-level expressions in model order, which need not
+# be the order parsnip recorded. When the fitted model did not retain its
+# outcome levels the names are positional placeholders (`class_0`, `class_1`),
+# so position is all there is to go on.
+order_prob_eqs <- function(prob_eqs, x, lvl, call) {
+  if (length(prob_eqs) != length(lvl)) {
+    cli::cli_abort(
+      "Model returned {length(prob_eqs)} expression{?s} for {length(lvl)}
+       outcome level{?s}.",
+      call = call
+    )
+  }
+
+  model_levels <- tidypredict::tidypredict_outcome_levels(x$fit)
+
+  if (is.null(model_levels)) {
+    return(unname(prob_eqs))
+  }
+
+  if (!setequal(model_levels, lvl)) {
+    cli::cli_abort(
+      c(
+        "Model's outcome levels do not match the ones {.pkg parsnip} recorded.",
+        i = "Model: {.val {model_levels}}.",
+        i = "Expected: {.val {lvl}}."
+      ),
+      call = call
+    )
+  }
+
+  unname(stats::setNames(prob_eqs, model_levels)[lvl])
+}
+
+# Backends that predict a class label and nothing else: there is no probability
+# to return and none can be derived, so asking for one is refused rather than
+# answered with a fabricated number.
+route_class <- function(res, x, type, call) {
+  if ("prob" %in% type) {
+    cli::cli_abort(
+      c(
+        "{.val prob} predictions are not available for this model.",
+        i = "It predicts a class directly, with no probability behind it.",
+        i = "Use {.code type = \"class\"} instead."
+      ),
+      call = call
+    )
+  }
+
+  c(orbital_tmp_class_name = deparse_eq(res, x, call))
+}
+
+deparse_eq <- function(res, x, call) {
+  if (!is.language(res)) {
+    cli::cli_abort(
+      "Expected a single expression, not {.obj_type_friendly {res}}.",
+      call = call
+    )
+  }
+
+  deparse1(res, control = "digits17")
+}
+
+abort_unsupported_output <- function(x, call) {
+  cls <- class(x)
+  cls <- setdiff(cls, "model_fit")
+  cls <- gsub("^_", "", cls)
+
+  cli::cli_abort(
+    c(
+      "Classification output for a model of class {.cls {cls}} is not yet
+       supported.",
+      i = "The model itself is supported for {.val regression} mode."
+    ),
+    call = call
+  )
+}

--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -61,7 +61,7 @@ orbital.model_fit <- function(
       }
     )
 
-    check_fallback_shape(res, x, mode, type)
+    res <- route_fallback(res, x, mode, type, call = rlang::call2("orbital"))
   }
 
   if (is.language(res)) {
@@ -91,38 +91,6 @@ abort_unsupported_model <- function(x) {
     "A model of class {.cls {cls}} is not supported.",
     call = rlang::call2("orbital")
   )
-}
-
-# `set_pred_names()` renames the sentinel names that orbital's own methods
-# attach. A tidypredict result for a classification model carries no such
-# names, so the sentinels would not match and the prediction columns would come
-# out named after tidypredict's internals. Refuse instead of emitting silently
-# mis-named columns.
-check_fallback_shape <- function(res, x, mode, type) {
-  if (mode != "classification") {
-    return(invisible(res))
-  }
-
-  eq_names <- names(res)
-  has_class <- "orbital_tmp_class_name" %in% eq_names
-  has_prob <- any(grepl("^orbital_tmp_prob_name", eq_names))
-
-  if (!has_class && !has_prob) {
-    cls <- class(x)
-    cls <- setdiff(cls, "model_fit")
-    cls <- gsub("^_", "", cls)
-
-    cli::cli_abort(
-      c(
-        "Classification output for a model of class {.cls {cls}} is not yet
-         supported.",
-        i = "The model itself is supported for {.val regression} mode."
-      ),
-      call = rlang::call2("orbital")
-    )
-  }
-
-  invisible(res)
 }
 
 set_pred_names <- function(res, x, mode, type, prefix) {

--- a/tests/testthat/_snaps/fallback-routing.md
+++ b/tests/testthat/_snaps/fallback-routing.md
@@ -1,0 +1,37 @@
+# a decision value routes to a cut at zero, and refuses prob
+
+    Code
+      orbital(fit, type = "prob")
+    Condition
+      Error in `orbital()`:
+      ! "prob" predictions are not available for this model.
+      i It produces an uncalibrated decision value rather than a probability.
+      i Use `type = "class"` instead.
+
+# a class-only model routes its label through, and refuses prob
+
+    Code
+      orbital(fit, type = "prob")
+    Condition
+      Error in `orbital()`:
+      ! "prob" predictions are not available for this model.
+      i It predicts a class directly, with no probability behind it.
+      i Use `type = "class"` instead.
+
+# a model tidypredict cannot describe is refused
+
+    Code
+      route_fallback(rlang::expr(1 + 1), fit, "classification", "class")
+    Condition
+      Error:
+      ! Classification output for a model of class <made_up> is not yet supported.
+      i The model itself is supported for "regression" mode.
+
+# a level-count mismatch is refused
+
+    Code
+      order_prob_eqs(c(a = "1", b = "2"), fit, fit$lvl, rlang::current_env())
+    Condition
+      Error:
+      ! Model returned 2 expressions for 3 outcome levels.
+

--- a/tests/testthat/_snaps/parsnip.md
+++ b/tests/testthat/_snaps/parsnip.md
@@ -14,15 +14,6 @@
       Error:
       ! Bug inside a native method.
 
-# check_fallback_shape() refuses unadapted classification output
-
-    Code
-      check_fallback_shape(c(a = "1 + 1"), fit, "classification", "class")
-    Condition
-      Error in `orbital()`:
-      ! Classification output for a model of class <made_up> is not yet supported.
-      i The model itself is supported for "regression" mode.
-
 # errors on invalid modes
 
     Code

--- a/tests/testthat/test-fallback-routing.R
+++ b/tests/testthat/test-fallback-routing.R
@@ -1,0 +1,139 @@
+binary_iris <- function() {
+  df <- iris
+  df$Species <- factor(df$Species == "setosa", labels = c("no", "yes"))
+  df
+}
+
+test_that("multiclass probabilities route through the adapter", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("discrim")
+  skip_if_not_installed("MASS")
+
+  fit <- parsnip::fit(
+    parsnip::set_engine(parsnip::discrim_linear(), "MASS"),
+    Species ~ .,
+    data = iris
+  )
+
+  obj <- orbital(fit, type = c("class", "prob"))
+  preds <- predict(obj, iris)
+
+  expect_equal(
+    as.matrix(preds[, c(
+      ".pred_setosa",
+      ".pred_versicolor",
+      ".pred_virginica"
+    )]),
+    as.matrix(predict(fit, iris, type = "prob")),
+    ignore_attr = TRUE
+  )
+  expect_equal(preds$.pred_class, as.character(predict(fit, iris)$.pred_class))
+})
+
+test_that("probabilities are reordered into parsnip's level order", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("discrim")
+  skip_if_not_installed("MASS")
+
+  # Reversing the factor levels makes model order and parsnip order disagree,
+  # so a positional pass-through would mislabel every column.
+  df <- iris
+  df$Species <- factor(df$Species, levels = rev(levels(df$Species)))
+
+  fit <- parsnip::fit(
+    parsnip::set_engine(parsnip::discrim_linear(), "MASS"),
+    Species ~ .,
+    data = df
+  )
+
+  obj <- orbital(fit, type = "prob")
+  preds <- predict(obj, df)
+
+  expect_equal(
+    as.matrix(preds),
+    as.matrix(predict(fit, df, type = "prob")),
+    ignore_attr = TRUE
+  )
+})
+
+test_that("a decision value routes to a cut at zero, and refuses prob", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("LiblineaR")
+
+  df <- binary_iris()
+  fit <- parsnip::fit(
+    parsnip::set_mode(
+      parsnip::set_engine(parsnip::svm_linear(), "LiblineaR"),
+      "classification"
+    ),
+    Species ~ .,
+    data = df
+  )
+
+  obj <- orbital(fit, type = "class")
+
+  expect_equal(
+    predict(obj, df)$.pred_class,
+    as.character(predict(fit, df)$.pred_class)
+  )
+  expect_snapshot(error = TRUE, orbital(fit, type = "prob"))
+})
+
+test_that("a class-only model routes its label through, and refuses prob", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("C50")
+
+  fit <- parsnip::fit(
+    parsnip::set_mode(
+      parsnip::set_engine(parsnip::boost_tree(trees = 3), "C5.0"),
+      "classification"
+    ),
+    Species ~ .,
+    data = iris
+  )
+
+  obj <- orbital(fit, type = "class")
+
+  expect_equal(
+    predict(obj, iris)$.pred_class,
+    as.character(predict(fit, iris)$.pred_class)
+  )
+  expect_snapshot(error = TRUE, orbital(fit, type = "prob"))
+})
+
+test_that("a model tidypredict cannot describe is refused", {
+  local_mocked_bindings(
+    tidypredict_output_type = function(x, ...) {
+      cli::cli_abort("no", class = "tidypredict_no_metadata")
+    }
+  )
+
+  fit <- structure(
+    list(fit = structure(list(), class = "made_up"), lvl = c("a", "b")),
+    class = c("_made_up", "model_fit")
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    route_fallback(rlang::expr(1 + 1), fit, "classification", "class")
+  )
+})
+
+test_that("regression output passes through untouched", {
+  fit <- structure(list(), class = c("_made_up", "model_fit"))
+  eq <- rlang::expr(1 + 1)
+
+  expect_identical(route_fallback(eq, fit, "regression", "numeric"), eq)
+})
+
+test_that("a level-count mismatch is refused", {
+  fit <- structure(
+    list(fit = structure(list(), class = "made_up"), lvl = c("a", "b", "c")),
+    class = c("_made_up", "model_fit")
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    order_prob_eqs(c(a = "1", b = "2"), fit, fit$lvl, rlang::current_env())
+  )
+})

--- a/tests/testthat/test-parsnip.R
+++ b/tests/testthat/test-parsnip.R
@@ -52,32 +52,6 @@ test_that("errors from native methods are not swallowed by the fallback", {
   expect_snapshot(error = TRUE, orbital(fit))
 })
 
-test_that("check_fallback_shape() refuses unadapted classification output", {
-  fit <- structure(list(), class = c("_made_up", "model_fit"))
-
-  expect_snapshot(
-    error = TRUE,
-    check_fallback_shape(c(a = "1 + 1"), fit, "classification", "class")
-  )
-
-  # Regression output needs no sentinel names, and orbital's own methods
-  # already carry them.
-  expect_invisible(check_fallback_shape(
-    c(a = "1"),
-    fit,
-    "regression",
-    "numeric"
-  ))
-  expect_invisible(
-    check_fallback_shape(
-      c(orbital_tmp_class_name = "1"),
-      fit,
-      "classification",
-      "class"
-    )
-  )
-})
-
 test_that("prefix argument works", {
   skip_if_not_installed("parsnip")
   skip_if_not_installed("tidypredict")


### PR DESCRIPTION
Completes phase 3. The adapters landed in #157; this wires them up.

orbital refused every classification model that reached the tidypredict fallback, because the result carries none of the sentinel names `set_pred_names()` renames, so the prediction columns would otherwise come out named after tidypredict's internals.

Choosing between the adapters needs to know what the result actually represents, and **that is not recoverable from its shape**. `tidypredict_output_type()` (from tidymodels/tidypredict#435) now says, so the routing asks rather than sniffs. This matters concretely: `LiblineaR` returns a single expression both for a probability and for an uncalibrated decision value, depending only on its `type` argument. Cutting a decision value at 0.5 gives silently wrong classes for every row whose value falls between 0 and 0.5.

## Four routes

| Output type | Route | `type = "prob"` |
|---|---|---|
| `prob`, single expression | `binary_from_prob()` | yes |
| `prob`, per-level list | reorder, then `multiclass_from_probs()` | yes |
| `decision` | `binary_from_decision()`, cut at 0 | refused |
| `class` | label passes through | refused |

The two refusals are deliberate. A decision value is uncalibrated, and a class-only model has no probability behind it at all, so in both cases producing one would mean inventing a calibration the model does not have.

## Reordering is not cosmetic

tidypredict returns the per-level expressions in model order, which need not be the order parsnip recorded. A positional pass-through would mislabel every probability column. There is a test that reverses the factor levels specifically so model order and parsnip order disagree.

When the fitted model did not retain its outcome levels, the names are positional placeholders (`class_0`, `class_1`) and position is all there is to go on, so the reorder is skipped rather than attempted against names that will never match.

## Verified end to end, by value

Not by snapshot. Against `predict()` on the fitted parsnip model:

- `MASS::lda()` multiclass: probabilities match to 2.9e-15, classes 150/150
- `LiblineaR` SVM: classes 150/150
- `C50::C5.0()`: classes 150/150

## Notes

`check_fallback_shape()` is superseded and removed. It existed to catch results that had no sentinel names; now every classification path either produces sentinels or aborts with a reason specific to why.

Adds `C50`, `discrim` and `LiblineaR` to Suggests, which the plan already anticipated as the cost of the `MASS::lda` test.

Suite goes 1096 to 1104 passing, no failures. `R CMD check` with vignettes: 0 errors, 0 warnings, 1 note (the worktree's `.git`).

One thing I noticed but did not change: the multiclass adapters name their intermediate columns after the bare outcome levels, so a dataset with a column called `setosa` would collide. That is pre-existing and consistent across all five adapters, including the ones on the native paths, so fixing it is a separate cross-cutting rename rather than part of this.