### PR TITLE
Add support for C5.0, bagged tree, and cforest models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     rlang
 Suggests:
     arrow,
+    baguette,
     bonsai,
     C50,
     DBI,
@@ -54,6 +55,7 @@ Suggests:
     rpart,
     RSQLite,
     rstanarm,
+    rules,
     sparklyr,
     splines2,
     tailor,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## New models
 
+* `bag_tree()` with the `"rpart"` and `"C5.0"` engines is now supported for `type = "class"`. These models vote over their ensemble and expose no probability, so `type = "prob"` is refused. (#161)
+
+* `boost_tree()` with the `"C5.0"` engine is now supported for `type = "class"`, including multi-trial boosting. (#161)
+
+* `C5_rules()` with the `"C5.0"` engine is now supported for `type = "class"`. (#161)
+
 * `discrim_linear()` and `discrim_quad()` with the `"MASS"` engine are now supported for `type = "class"` and `type = "prob"`. (#160)
 
 * `linear_reg()` with the `"glm"` engine is now supported. (#160)
@@ -11,6 +17,8 @@
 * `multinom_reg()` with the `"nnet"` engine is now supported for `type = "class"` and `type = "prob"`. (#160)
 
 * `null_model()` is now supported for regression and classification. (#160)
+
+* `rand_forest()` with the `"partykit"` engine is now supported for regression. (#161)
 
 ## Improvements
 

--- a/tests/testthat/_snaps/model-C50.md
+++ b/tests/testthat/_snaps/model-C50.md
@@ -1,0 +1,10 @@
+# boost_tree(C5.0) errors for type = prob
+
+    Code
+      orbital(fit, type = "prob")
+    Condition
+      Error in `orbital()`:
+      ! "prob" predictions are not available for this model.
+      i It predicts a class directly, with no probability behind it.
+      i Use `type = "class"` instead.
+

--- a/tests/testthat/_snaps/model-baguette.md
+++ b/tests/testthat/_snaps/model-baguette.md
@@ -1,0 +1,10 @@
+# bag_tree() errors for type = prob
+
+    Code
+      orbital(fit, type = "prob")
+    Condition
+      Error in `orbital()`:
+      ! "prob" predictions are not available for this model.
+      i It predicts a class directly, with no probability behind it.
+      i Use `type = "class"` instead.
+

--- a/tests/testthat/_snaps/model-partykit.md
+++ b/tests/testthat/_snaps/model-partykit.md
@@ -1,0 +1,10 @@
+# rand_forest(partykit) errors for classification
+
+    Code
+      orbital(fit, type = "class")
+    Condition
+      Error in `cforest_check_regression()`:
+      ! Classification models are not supported for cforest.
+      i Only regression models can be converted to tidy formulas.
+      i Classification requires a voting mechanism that cannot be expressed as a single formula.
+

--- a/tests/testthat/test-model-C50.R
+++ b/tests/testthat/test-model-C50.R
@@ -1,0 +1,111 @@
+skip_if_no_C50 <- function() {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("C50")
+}
+
+binary_iris <- function() {
+  droplevels(iris[iris$Species != "setosa", ])
+}
+
+test_that("boost_tree(C5.0) works with type = class for binary outcomes", {
+  skip_if_no_C50()
+
+  data <- binary_iris()
+  spec <- parsnip::boost_tree(
+    trees = 1,
+    mode = "classification",
+    engine = "C5.0"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., data)
+
+  preds <- predict(orbital(fit, type = "class"), data)
+
+  expect_named(preds, ".pred_class")
+  expect_identical(
+    preds$.pred_class,
+    as.character(predict(fit, data)$.pred_class)
+  )
+})
+
+test_that("boost_tree(C5.0) works with type = class for multiclass outcomes", {
+  skip_if_no_C50()
+
+  spec <- parsnip::boost_tree(
+    trees = 1,
+    mode = "classification",
+    engine = "C5.0"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  preds <- predict(orbital(fit, type = "class"), iris)
+
+  expect_identical(
+    preds$.pred_class,
+    as.character(predict(fit, iris)$.pred_class)
+  )
+})
+
+test_that("boost_tree(C5.0) works with more than one boosting round", {
+  skip_if_no_C50()
+
+  # Boosting combines the trees by confidence-weighted vote rather than by a
+  # plain majority, so a multi-trial fit exercises a different code path in
+  # tidypredict than the single-tree case above.
+  spec <- parsnip::boost_tree(
+    trees = 5,
+    mode = "classification",
+    engine = "C5.0"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  preds <- predict(orbital(fit, type = "class"), iris)
+
+  expect_identical(
+    preds$.pred_class,
+    as.character(predict(fit, iris)$.pred_class)
+  )
+})
+
+test_that("C5_rules() works with type = class", {
+  skip_if_no_C50()
+  skip_if_not_installed("rules")
+
+  spec <- parsnip::set_engine(parsnip::C5_rules(trees = 1), "C5.0")
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  preds <- predict(orbital(fit, type = "class"), iris)
+
+  expect_identical(
+    preds$.pred_class,
+    as.character(predict(fit, iris)$.pred_class)
+  )
+})
+
+test_that("boost_tree(C5.0) works with custom prefix", {
+  skip_if_no_C50()
+
+  spec <- parsnip::boost_tree(
+    trees = 1,
+    mode = "classification",
+    engine = "C5.0"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  preds <- predict(orbital(fit, type = "class", prefix = "my_pred"), iris)
+
+  expect_named(preds, "my_pred_class")
+})
+
+test_that("boost_tree(C5.0) errors for type = prob", {
+  skip_if_no_C50()
+
+  spec <- parsnip::boost_tree(
+    trees = 1,
+    mode = "classification",
+    engine = "C5.0"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  expect_snapshot(error = TRUE, orbital(fit, type = "prob"))
+})

--- a/tests/testthat/test-model-baguette.R
+++ b/tests/testthat/test-model-baguette.R
@@ -1,0 +1,74 @@
+skip_if_no_baguette <- function() {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("baguette")
+}
+
+test_that("bag_tree(rpart) works with type = class for binary outcomes", {
+  skip_if_no_baguette()
+  skip_if_not_installed("rpart")
+
+  data <- droplevels(iris[iris$Species != "setosa", ])
+  spec <- parsnip::set_engine(
+    parsnip::set_mode(parsnip::bag_tree(), "classification"),
+    "rpart"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., data)
+
+  preds <- predict(orbital(fit, type = "class"), data)
+
+  expect_named(preds, ".pred_class")
+  expect_identical(
+    preds$.pred_class,
+    as.character(predict(fit, data)$.pred_class)
+  )
+})
+
+test_that("bag_tree(rpart) works with type = class for multiclass outcomes", {
+  skip_if_no_baguette()
+  skip_if_not_installed("rpart")
+
+  spec <- parsnip::set_engine(
+    parsnip::set_mode(parsnip::bag_tree(), "classification"),
+    "rpart"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  preds <- predict(orbital(fit, type = "class"), iris)
+
+  expect_identical(
+    preds$.pred_class,
+    as.character(predict(fit, iris)$.pred_class)
+  )
+})
+
+test_that("bag_tree(C5.0) works with type = class", {
+  skip_if_no_baguette()
+  skip_if_not_installed("C50")
+
+  spec <- parsnip::set_engine(
+    parsnip::set_mode(parsnip::bag_tree(), "classification"),
+    "C5.0"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  preds <- predict(orbital(fit, type = "class"), iris)
+
+  expect_identical(
+    preds$.pred_class,
+    as.character(predict(fit, iris)$.pred_class)
+  )
+})
+
+test_that("bag_tree() errors for type = prob", {
+  skip_if_no_baguette()
+  skip_if_not_installed("rpart")
+
+  spec <- parsnip::set_engine(
+    parsnip::set_mode(parsnip::bag_tree(), "classification"),
+    "rpart"
+  )
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  expect_snapshot(error = TRUE, orbital(fit, type = "prob"))
+})

--- a/tests/testthat/test-model-partykit.R
+++ b/tests/testthat/test-model-partykit.R
@@ -118,6 +118,51 @@ test_that("decision_tree(partykit) works with type = c(class, prob)", {
   )
 })
 
+test_that("rand_forest(partykit) works with type = numeric", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("bonsai")
+  skip_if_not_installed("tidypredict")
+
+  spec <- parsnip::rand_forest(
+    trees = 5,
+    mode = "regression",
+    engine = "partykit"
+  )
+
+  set.seed(1234)
+  fit <- parsnip::fit(spec, mpg ~ disp + vs + hp, mtcars)
+
+  preds <- predict(orbital(fit), mtcars)
+  exps <- as.data.frame(predict(fit, mtcars))
+
+  expect_named(preds, ".pred")
+  expect_type(preds$.pred, "double")
+
+  rownames(preds) <- NULL
+  rownames(exps) <- NULL
+
+  expect_equal(preds, exps)
+})
+
+test_that("rand_forest(partykit) errors for classification", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("bonsai")
+  skip_if_not_installed("tidypredict")
+
+  mtcars$vs <- factor(mtcars$vs)
+
+  spec <- parsnip::rand_forest(
+    trees = 5,
+    mode = "classification",
+    engine = "partykit"
+  )
+
+  set.seed(1234)
+  fit <- parsnip::fit(spec, vs ~ disp + mpg + hp, mtcars)
+
+  expect_snapshot(error = TRUE, orbital(fit, type = "class"))
+})
+
 test_that("decision_tree(partykit) works with custom prefix", {
   skip_if_not_installed("parsnip")
   skip_if_not_installed("bonsai")

--- a/vignettes/supported-models.Rmd
+++ b/vignettes/supported-models.Rmd
@@ -34,9 +34,13 @@ library(dplyr)
 
 tibble::tribble(
   ~parsnip,               ~engine,              ~numeric, ~class, ~prob,
+  "`bag_tree()`",         "`\"C5.0\"`",         "❌",     "✅",    "❌",
+  "`bag_tree()`",         "`\"rpart\"`",        "❌",     "✅",    "❌",
+  "`boost_tree()`",       "`\"C5.0\"`",         "❌",     "✅",    "❌",
   "`boost_tree()`",       "`\"catboost\"`",     "✅",     "✅",    "✅",
   "`boost_tree()`",       "`\"lightgbm\"`",     "✅",     "✅",    "✅",
   "`boost_tree()`",       "`\"xgboost\"`",      "✅",     "✅",    "✅",
+  "`C5_rules()`",         "`\"C5.0\"`",         "❌",     "✅",    "❌",
   "`cubist_rules()`",     "`\"Cubist\"`",       "✅",     "❌",    "❌",
   "`decision_tree()`",    "`\"partykit\"`",     "✅",     "✅",    "✅",
   "`decision_tree()`",    "`\"rpart\"`",        "✅",     "✅",    "✅",
@@ -54,6 +58,7 @@ tibble::tribble(
   "`naive_Bayes()`",      "`\"naivebayes\"`",   "❌",     "⚪",    "⚪",
   "`nearest_neighbor()`", "`any`",              "❌",     "❌",    "❌",
   "`null_model()`",       "`\"parsnip\"`",      "✅",     "✅",    "✅",
+  "`rand_forest()`",      "`\"partykit\"`",     "✅",     "❌",    "❌",
   "`rand_forest()`",      "`\"randomForest\"`", "✅",     "✅",    "✅",
   "`rand_forest()`",      "`\"ranger\"`",       "✅",     "✅",    "✅"
 ) |>


### PR DESCRIPTION
Part of phase 4 tier 2. Adds six backends, all of which work through the generic paths already in place, so the diff is tests, docs, and `Suggests` only.

| parsnip | engine | modes |
| --- | --- | --- |
| `boost_tree()` | `"C5.0"` | class (single tree and boosted) |
| `C5_rules()` | `"C5.0"` | class |
| `bag_tree()` | `"rpart"` | class |
| `bag_tree()` | `"C5.0"` | class |
| `rand_forest()` | `"partykit"` | numeric |

All six agree exactly with `predict()`: the five classification backends match the predicted label on every row of binary and multiclass `iris`, and cforest regression matches to 6.2e-15.

## Class-only, and why

The C5.0 and bagged backends vote over an ensemble and expose no probability, so they report `tidypredict_output_type() == "class"` and the phase 3 routing from #159 refuses `type = "prob"` rather than fabricating one. cforest is the mirror image: tidypredict declines classification outright because the vote cannot be expressed as a single formula, so it is regression-only. Both refusals are snapshotted so the messages stay put.

## Not in this PR

Three of the nine backends the plan lists for tier 2 are held back, each for a different reason:

- **dbarts** works and is exact against `tidypredict_fit()` (8.9e-16), but `predict()` on a bart fit draws from the posterior, so two consecutive calls on the same data differ by more than orbital differs from either. It needs a test written against a non-`predict()` reference plus a documented caveat, which is its own PR.
- **aorsf** disagrees twice over: orbital differs from `tidypredict_fit()` by 0.032, and `tidypredict_fit()` differs from aorsf's own `predict()` by 0.085, on a log10 outcome. Deterministic, so these are two real bugs and at least one of them is upstream.
- **blackboost** has no parsnip engine to reach it. `show_engines("boost_tree")` lists no `"mboost"` entry; mboost is registered only by censored, for survival mode, which orbital does not support. It should come off the tier 2 list.
