### PR TITLE
Add support for dbarts BART regression models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Suggests:
     baguette,
     bonsai,
     C50,
+    dbarts,
     DBI,
     discrim,
     dbplyr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `bag_tree()` with the `"rpart"` and `"C5.0"` engines is now supported for `type = "class"`. These models vote over their ensemble and expose no probability, so `type = "prob"` is refused. (#161)
 
+* `bart()` with the `"dbarts"` engine is now supported for regression. Classification is refused, since it uses a probit link that cannot be translated. (#162)
+
 * `boost_tree()` with the `"C5.0"` engine is now supported for `type = "class"`, including multi-trial boosting. (#161)
 
 * `C5_rules()` with the `"C5.0"` engine is now supported for `type = "class"`. (#161)

--- a/tests/testthat/_snaps/model-dbarts.md
+++ b/tests/testthat/_snaps/model-dbarts.md
@@ -1,0 +1,10 @@
+# bart(dbarts) errors for classification
+
+    Code
+      orbital(fit, type = "class")
+    Condition
+      Error in `check_bart_supported()`:
+      ! Classification `dbarts::bart()` models are not supported.
+      i Only regression models can be converted to tidy formulas.
+      i Classification uses the probit link, which cannot be translated to SQL.
+

--- a/tests/testthat/test-model-dbarts.R
+++ b/tests/testthat/test-model-dbarts.R
@@ -1,0 +1,57 @@
+skip_if_no_dbarts <- function() {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("dbarts")
+}
+
+# `predict()` on a BART model draws from the posterior, so it returns different
+# numbers on every call and cannot be used as a reference. Compare against the
+# formula tidypredict extracts from the fit instead.
+tidypredict_reference <- function(fit, data) {
+  rlang::eval_tidy(
+    tidypredict::tidypredict_fit(fit$fit),
+    data = data,
+    env = asNamespace("dplyr")
+  )
+}
+
+test_that("bart(dbarts) works with type = numeric", {
+  skip_if_no_dbarts()
+
+  spec <- parsnip::bart(trees = 5, mode = "regression", engine = "dbarts")
+
+  set.seed(1234)
+  fit <- parsnip::fit(spec, mpg ~ disp + vs + hp, mtcars)
+
+  preds <- predict(orbital(fit), mtcars)
+
+  expect_named(preds, ".pred")
+  expect_type(preds$.pred, "double")
+  expect_equal(preds$.pred, tidypredict_reference(fit, mtcars))
+})
+
+test_that("bart(dbarts) works with custom prefix", {
+  skip_if_no_dbarts()
+
+  spec <- parsnip::bart(trees = 5, mode = "regression", engine = "dbarts")
+
+  set.seed(1234)
+  fit <- parsnip::fit(spec, mpg ~ disp + vs + hp, mtcars)
+
+  preds <- predict(orbital(fit, prefix = "my_pred"), mtcars)
+
+  expect_named(preds, "my_pred")
+})
+
+test_that("bart(dbarts) errors for classification", {
+  skip_if_no_dbarts()
+
+  mtcars$vs <- factor(mtcars$vs)
+
+  spec <- parsnip::bart(trees = 5, mode = "classification", engine = "dbarts")
+
+  set.seed(1234)
+  fit <- parsnip::fit(spec, vs ~ disp + mpg + hp, mtcars)
+
+  expect_snapshot(error = TRUE, orbital(fit, type = "class"))
+})

--- a/vignettes/supported-models.Rmd
+++ b/vignettes/supported-models.Rmd
@@ -36,6 +36,7 @@ tibble::tribble(
   ~parsnip,               ~engine,              ~numeric, ~class, ~prob,
   "`bag_tree()`",         "`\"C5.0\"`",         "❌",     "✅",    "❌",
   "`bag_tree()`",         "`\"rpart\"`",        "❌",     "✅",    "❌",
+  "`bart()`",             "`\"dbarts\"`",       "✅",     "❌",    "❌",
   "`boost_tree()`",       "`\"C5.0\"`",         "❌",     "✅",    "❌",
   "`boost_tree()`",       "`\"catboost\"`",     "✅",     "✅",    "✅",
   "`boost_tree()`",       "`\"lightgbm\"`",     "✅",     "✅",    "✅",


### PR DESCRIPTION
`bart()` with the `"dbarts"` engine now round-trips through orbital for regression. No new orbital code was needed: this is tests, docs, and a `Suggests` entry. Classification is refused upstream by tidypredict, because BART classification uses a probit link that cannot be translated to SQL, and that refusal is captured in a snapshot.

### The reference problem

BART draws from the posterior, so `predict()` returns different numbers on every call. This nearly got written up as an orbital bug: the first probe reported a 0.12 gap against `predict()` and looked like a wrong answer. But two consecutive `predict()` calls on identical data differ by 0.18, which is *larger* than the gap being investigated. The reference was wrong, not the code.

The test therefore compares against the formula `tidypredict_fit()` extracts from the fit, which orbital matches to 3.6e-15. The helper that does this carries a comment explaining why, so the next person to read the file doesn't 'fix' it back to `predict()`.

### Testing

Full local suite: `FAIL 0 | WARN 4 | SKIP 10 | PASS 1156`, with the same warnings and skips as before the change.

Part of the tidypredict backend expansion; this was the deferred item from the tree-ensemble group.
