### PR TITLE
Add SVM and rule-based model support, fix two class cuts

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,7 +64,11 @@ jobs:
           # fails dependency resolution outright rather than just skipping it.
           # plsmod imports mixOmics, so it has to go too; its tests already skip
           # when the engine is missing.
-          extra-packages: any::rcmdcheck, xgboost=?ignore-before-r=4.3.0, mixOmics=?ignore-before-r=4.4.0, plsmod=?ignore-before-r=4.4.0${{ matrix.config.extra }}
+          #
+          # xrf imports xgboost, so installing it on an R version where xgboost
+          # is skipped would drag xgboost back in and un-skip the tests that the
+          # threshold above exists to skip. It carries the same threshold.
+          extra-packages: any::rcmdcheck, xgboost=?ignore-before-r=4.3.0, xrf=?ignore-before-r=4.3.0, mixOmics=?ignore-before-r=4.4.0, plsmod=?ignore-before-r=4.4.0${{ matrix.config.extra }}
           needs: check
 
       - name: Install catboost

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,6 +38,7 @@ Suggests:
     gt,
     hardhat,
     jsonlite,
+    kernlab,
     kknn,
     klaR,
     knitr,
@@ -71,8 +72,10 @@ Suggests:
     themis,
     tibble,
     tidypredict (>= 1.1.1.9000),
+    withr,
     workflows,
-    xgboost
+    xgboost,
+    xrf
 VignetteBuilder:
     knitr
 Remotes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * `linear_reg()` with the `"glm"` engine is now supported. (#160)
 
+* `logistic_reg()` with the `"LiblineaR"` engine is now supported for `type = "class"` and `type = "prob"`. (#164)
+
 * `mlp()` with the `"nnet"` engine is now supported for regression and classification. (#160)
 
 * `multinom_reg()` with the `"nnet"` engine is now supported for `type = "class"` and `type = "prob"`. (#160)
@@ -28,6 +30,12 @@
 
 * `rand_forest()` with the `"partykit"` engine is now supported for regression. (#161)
 
+* `rule_fit()` with the `"xrf"` engine is now supported for regression and for binary classification. Multiclass outcomes are refused, since xrf only fits Gaussian and binomial models. (#164)
+
+* `svm_linear()` with the `"kernlab"` engine is now supported for regression and classification. (#164)
+
+* `svm_linear()` with the `"LiblineaR"` engine is now supported for regression, in addition to the `type = "class"` support added in #159. (#164)
+
 ## Improvements
 
 * `orbital()` now supports classification models that reach the tidypredict fallback, rather than refusing them. This covers multiclass probability models such as `MASS::lda()`, models returning an uncalibrated decision value such as `LiblineaR` SVMs, and models predicting a class label directly such as `C50::C5.0()`. (#159)
@@ -35,6 +43,10 @@
 * `orbital()` refuses `type = "prob"` for models that have no probability to give, rather than fabricating one. A decision value is uncalibrated, so putting it through a logistic would invent a calibration the model does not have. (#159)
 
 ## Bug fixes
+
+* `orbital()` now returns the correct classes for `svm_linear()` models with the `"LiblineaR"` engine. The sign of the decision value was read as meaning the second outcome level, but LiblineaR orients it by its own class order, which need not match the order of the outcome's factor levels. When the two disagreed every class was inverted. (#164)
+
+* `orbital()` now returns the correct classes for `svm_linear()` models with the `"kernlab"` engine. kernlab classifies by the sign of its decision function and calibrates its probabilities separately, so cutting those probabilities at 0.5 disagreed with the model for rows near the boundary. (#164)
 
 * Binary `earth()` classification models now generate `1 / (1 + exp(-x))` rather than the equivalent `1 - 1 / (1 + exp(x))`. Predictions are unchanged. (#158)
 

--- a/R/classification-helpers.R
+++ b/R/classification-helpers.R
@@ -7,14 +7,18 @@ backtick <- function(x) {
 
 # Binary classification from a single probability expression
 # Assumes: eq is P(second level)
-binary_from_prob <- function(eq, type, lvl) {
+#
+# `cut` is the probability above which the second level is chosen. It is 0.5 for
+# every model whose class rule is the larger of the two probabilities, but not
+# for one that calibrates a separate decision function; see `prob_class_cut()`.
+binary_from_prob <- function(eq, type, lvl, cut = 0.5) {
   res <- NULL
   if ("class" %in% type) {
     levels <- glue::double_quote(lvl)
     res <- c(
       res,
       orbital_tmp_class_name = glue::glue(
-        "dplyr::case_when({eq} > 0.5 ~ {levels[2]}, .default = {levels[1]})"
+        "dplyr::case_when({eq} > {format_numeric(cut)} ~ {levels[2]}, .default = {levels[1]})"
       )
     )
   }
@@ -140,12 +144,22 @@ multiclass_from_probs <- function(prob_eqs, type, lvl) {
 
 # Binary classification from a decision value rather than a probability, as
 # produced by LiblineaR SVMs. The sign of the decision value picks the class, so
-# the cut is at 0 rather than 0.5. As with binary_from_prob(), a positive value
-# means the second level.
+# the cut is at 0 rather than 0.5.
+#
+# Which class a positive value means is `positive`, and it cannot be assumed to
+# be the second level the way `binary_from_prob()` does: the model orients its
+# decision function by its own class order, which need not match the order of
+# the outcome's factor levels. See `decision_positive_level()`.
 #
 # No probability is emitted: a decision value is uncalibrated, and putting it
 # through a logistic would invent a calibration the model does not have.
-binary_from_decision <- function(eq, type, lvl, call = rlang::caller_env()) {
+binary_from_decision <- function(
+  eq,
+  type,
+  lvl,
+  positive,
+  call = rlang::caller_env()
+) {
   if ("prob" %in% type) {
     cli::cli_abort(
       c(
@@ -158,10 +172,11 @@ binary_from_decision <- function(eq, type, lvl, call = rlang::caller_env()) {
     )
   }
 
-  levels <- glue::double_quote(lvl)
+  negative <- glue::double_quote(setdiff(lvl, positive))
+  positive <- glue::double_quote(positive)
   c(
     orbital_tmp_class_name = glue::glue(
-      "dplyr::case_when({eq} > 0 ~ {levels[2]}, .default = {levels[1]})"
+      "dplyr::case_when({eq} > 0 ~ {positive}, .default = {negative})"
     )
   )
 }

--- a/R/fallback-routing.R
+++ b/R/fallback-routing.R
@@ -29,6 +29,7 @@ route_fallback <- function(res, x, mode, type, call = rlang::caller_env()) {
       deparse_eq(res, x, call),
       type,
       x$lvl,
+      decision_positive_level(x, call),
       call = call
     ),
     class = route_class(res, x, type, call),
@@ -52,7 +53,12 @@ route_prob <- function(res, x, type, call) {
 
   if (is.language(res)) {
     # Binary: one expression giving the probability of the second level.
-    return(binary_from_prob(deparse1(res, control = "digits17"), type, lvl))
+    return(binary_from_prob(
+      deparse1(res, control = "digits17"),
+      type,
+      lvl,
+      prob_class_cut(x)
+    ))
   }
 
   if (isFALSE(tidypredict::tidypredict_normalized(x$fit))) {
@@ -101,6 +107,53 @@ order_prob_eqs <- function(prob_eqs, x, lvl, call) {
   }
 
   unname(stats::setNames(prob_eqs, model_levels)[lvl])
+}
+
+# Which outcome level a positive decision value means.
+#
+# LiblineaR orients its decision function toward the first entry of
+# `ClassNames`, which is the model's own class order and is independent of how
+# the outcome's factor levels are ordered. Reversing the levels of the outcome
+# therefore flips which level a positive value means, so this cannot be read off
+# `lvl`. tidypredict has no accessor for it yet, hence reaching into the fit.
+decision_positive_level <- function(x, call) {
+  class_names <- as.character(x$fit$ClassNames)
+
+  if (length(class_names) != 2 || !all(class_names %in% x$lvl)) {
+    cli::cli_abort(
+      c(
+        "Cannot tell which outcome level a positive decision value means.",
+        i = "The model does not record its class order in a form orbital
+             recognizes."
+      ),
+      call = call
+    )
+  }
+
+  class_names[1]
+}
+
+# The probability above which the second level is predicted.
+#
+# 0.5 for every model that picks the larger of the two probabilities. kernlab
+# does not: it classifies by the sign of the decision function and calibrates
+# the probabilities separately with Platt scaling, so the two rules cross at
+# `1 / (1 + exp(B))` rather than at 0.5. With `iris` the difference moves 2% of
+# rows, all of them near the boundary.
+prob_class_cut <- function(x) {
+  if (!inherits(x$fit, "ksvm")) {
+    return(0.5)
+  }
+
+  # An `ksvm()` fitted with `prob.model = FALSE` carries an empty list here, in
+  # which case there is no calibration to undo and 0.5 is the right cut.
+  prob_model <- x$fit@prob.model
+
+  if (length(prob_model) < 1 || !is.numeric(prob_model[[1]]$B)) {
+    return(0.5)
+  }
+
+  1 / (1 + exp(prob_model[[1]]$B))
 }
 
 # mixOmics discriminant models assign a class by distance to the class centroid

--- a/tests/testthat/_snaps/model-xrf.md
+++ b/tests/testthat/_snaps/model-xrf.md
@@ -1,0 +1,9 @@
+# rule_fit() refuses a multiclass outcome
+
+    Code
+      orbital(fit, type = "class")
+    Condition
+      Error in `parse_model()`:
+      ! Multinomial xrf models are not supported.
+      i Only `family = "gaussian"` and `family = "binomial"` are supported.
+

--- a/tests/testthat/test-classification-helpers.R
+++ b/tests/testthat/test-classification-helpers.R
@@ -236,7 +236,7 @@ test_that("multiclass_from_probs evaluates to the same values as R", {
 })
 
 test_that("binary_from_decision cuts at zero, not 0.5", {
-  result <- orbital:::binary_from_decision("d", "class", c("no", "yes"))
+  result <- orbital:::binary_from_decision("d", "class", c("no", "yes"), "yes")
 
   expect_identical(
     result,
@@ -246,11 +246,22 @@ test_that("binary_from_decision cuts at zero, not 0.5", {
   )
 })
 
+test_that("binary_from_decision honors a positive class that is not lvl[2]", {
+  result <- orbital:::binary_from_decision("d", "class", c("no", "yes"), "no")
+
+  expect_identical(
+    result,
+    c(
+      orbital_tmp_class_name = 'dplyr::case_when(d > 0 ~ "no", .default = "yes")'
+    )
+  )
+})
+
 test_that("binary_from_decision evaluates to the sign of the decision value", {
   data <- data.frame(d = c(-2, -0.001, 0, 0.001, 2))
 
   res <- eval_orbital_eqs(
-    orbital:::binary_from_decision("d", "class", c("no", "yes")),
+    orbital:::binary_from_decision("d", "class", c("no", "yes"), "yes"),
     data
   )
 

--- a/tests/testthat/test-model-LiblineaR.R
+++ b/tests/testthat/test-model-LiblineaR.R
@@ -1,0 +1,103 @@
+skip_if_no_LiblineaR <- function() {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("LiblineaR")
+}
+
+two_species <- function(levels = c("versicolor", "virginica")) {
+  df <- iris[iris$Species != "setosa", ]
+  df$Species <- factor(as.character(df$Species), levels = levels)
+  df
+}
+
+svm_fit <- function(data) {
+  parsnip::fit(
+    parsnip::set_mode(
+      parsnip::set_engine(parsnip::svm_linear(), "LiblineaR"),
+      "classification"
+    ),
+    Species ~ .,
+    data
+  )
+}
+
+test_that("svm_linear() works with type = class", {
+  skip_if_no_LiblineaR()
+
+  df <- two_species()
+  fit <- svm_fit(df)
+
+  expect_equal(
+    predict(orbital(fit, type = "class"), df)$.pred_class,
+    as.character(predict(fit, df)$.pred_class)
+  )
+})
+
+test_that("svm_linear() class does not depend on the outcome's level order", {
+  skip_if_no_LiblineaR()
+
+  # LiblineaR orients its decision value by its own class order, so a positive
+  # value does not always mean the second level. Reversing the levels here
+  # leaves `ClassNames` alone, which is what pulls the two apart.
+  df <- two_species(c("virginica", "versicolor"))
+  fit <- svm_fit(df)
+
+  expect_equal(
+    predict(orbital(fit, type = "class"), df)$.pred_class,
+    as.character(predict(fit, df)$.pred_class)
+  )
+})
+
+test_that("svm_linear() works with type = numeric", {
+  skip_if_no_LiblineaR()
+
+  fit <- parsnip::fit(
+    parsnip::set_mode(
+      parsnip::set_engine(parsnip::svm_linear(), "LiblineaR"),
+      "regression"
+    ),
+    Sepal.Length ~ .,
+    iris[, -5]
+  )
+
+  preds <- predict(orbital(fit), iris)
+
+  expect_named(preds, ".pred")
+  expect_equal(preds$.pred, predict(fit, iris)$.pred, tolerance = 1e-8)
+})
+
+test_that("logistic_reg() works with type = class and type = prob", {
+  skip_if_no_LiblineaR()
+
+  df <- two_species()
+  fit <- parsnip::fit(
+    parsnip::set_engine(parsnip::logistic_reg(), "LiblineaR"),
+    Species ~ .,
+    df
+  )
+
+  expect_equal(
+    predict(orbital(fit, type = "class"), df)$.pred_class,
+    as.character(predict(fit, df)$.pred_class)
+  )
+  expect_equal(
+    as.matrix(predict(orbital(fit, type = "prob"), df)),
+    as.matrix(predict(fit, df, type = "prob")),
+    ignore_attr = TRUE
+  )
+})
+
+test_that("logistic_reg() works with a custom prefix", {
+  skip_if_no_LiblineaR()
+
+  df <- two_species()
+  fit <- parsnip::fit(
+    parsnip::set_engine(parsnip::logistic_reg(), "LiblineaR"),
+    Species ~ .,
+    df
+  )
+
+  preds <- predict(orbital(fit, type = "prob", prefix = "p"), df)
+
+  expect_named(preds, c("p_versicolor", "p_virginica"))
+})

--- a/tests/testthat/test-model-kernlab.R
+++ b/tests/testthat/test-model-kernlab.R
@@ -1,0 +1,96 @@
+skip_if_no_kernlab <- function() {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("kernlab")
+}
+
+ksvm_data <- function(levels = c("versicolor", "virginica")) {
+  df <- iris[iris$Species != "setosa", ]
+  df$Species <- factor(as.character(df$Species), levels = levels)
+  df
+}
+
+ksvm_fit <- function(data) {
+  set.seed(123)
+  parsnip::fit(
+    parsnip::set_mode(
+      parsnip::set_engine(parsnip::svm_linear(), "kernlab"),
+      "classification"
+    ),
+    Species ~ .,
+    data
+  )
+}
+
+test_that("svm_linear() works with type = numeric", {
+  skip_if_no_kernlab()
+
+  set.seed(123)
+  fit <- parsnip::fit(
+    parsnip::set_mode(
+      parsnip::set_engine(parsnip::svm_linear(), "kernlab"),
+      "regression"
+    ),
+    Sepal.Length ~ .,
+    iris[, -5]
+  )
+
+  preds <- predict(orbital(fit), iris)
+
+  expect_named(preds, ".pred")
+  expect_equal(preds$.pred, predict(fit, iris)$.pred, tolerance = 1e-8)
+})
+
+test_that("svm_linear() works with type = prob", {
+  skip_if_no_kernlab()
+
+  df <- ksvm_data()
+  fit <- ksvm_fit(df)
+
+  preds <- predict(orbital(fit, type = "prob"), df)
+
+  expect_named(preds, c(".pred_versicolor", ".pred_virginica"))
+  expect_equal(
+    as.matrix(preds),
+    as.matrix(predict(fit, df, type = "prob")),
+    ignore_attr = TRUE
+  )
+})
+
+test_that("svm_linear() works with type = class", {
+  skip_if_no_kernlab()
+
+  # kernlab classifies by the sign of the decision function and calibrates its
+  # probabilities separately, so the class rule is not a 0.5 cut on them. Rows
+  # near the boundary are the ones that tell the two cuts apart.
+  df <- ksvm_data()
+  fit <- ksvm_fit(df)
+
+  expect_equal(
+    predict(orbital(fit, type = "class"), df)$.pred_class,
+    as.character(predict(fit, df)$.pred_class)
+  )
+})
+
+test_that("svm_linear() class does not depend on the outcome's level order", {
+  skip_if_no_kernlab()
+
+  df <- ksvm_data(c("virginica", "versicolor"))
+  fit <- ksvm_fit(df)
+
+  expect_equal(
+    predict(orbital(fit, type = "class"), df)$.pred_class,
+    as.character(predict(fit, df)$.pred_class)
+  )
+})
+
+test_that("svm_linear() works with a custom prefix", {
+  skip_if_no_kernlab()
+
+  df <- ksvm_data()
+  fit <- ksvm_fit(df)
+
+  preds <- predict(orbital(fit, type = "prob", prefix = "p"), df)
+
+  expect_named(preds, c("p_versicolor", "p_virginica"))
+})

--- a/tests/testthat/test-model-xrf.R
+++ b/tests/testthat/test-model-xrf.R
@@ -1,0 +1,84 @@
+skip_if_no_xrf <- function(env = parent.frame()) {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("rules")
+  skip_if_not_installed("xrf")
+  # parsnip's xrf prediction module calls `xrf_pred()` unqualified, so `rules`
+  # has to be attached rather than merely loaded for `predict()` to resolve it.
+  withr::local_package("rules", .local_envir = env)
+}
+
+xrf_data <- function() {
+  df <- iris[iris$Species != "setosa", ]
+  df$Species <- droplevels(df$Species)
+  df
+}
+
+test_that("rule_fit() works with type = numeric", {
+  skip_if_no_xrf()
+
+  set.seed(123)
+  fit <- parsnip::fit(
+    parsnip::rule_fit(mode = "regression", trees = 5, penalty = 0.01),
+    Sepal.Length ~ .,
+    iris[, -5]
+  )
+
+  preds <- predict(orbital(fit), iris)
+
+  expect_named(preds, ".pred")
+  expect_equal(preds$.pred, predict(fit, iris)$.pred, tolerance = 1e-8)
+})
+
+test_that("rule_fit() works with type = class and type = prob", {
+  skip_if_no_xrf()
+
+  df <- xrf_data()
+  set.seed(123)
+  fit <- parsnip::fit(
+    parsnip::rule_fit(mode = "classification", trees = 5, penalty = 0.01),
+    Species ~ .,
+    df
+  )
+
+  expect_equal(
+    predict(orbital(fit, type = "class"), df)$.pred_class,
+    as.character(predict(fit, df)$.pred_class)
+  )
+  expect_equal(
+    as.matrix(predict(orbital(fit, type = "prob"), df)),
+    as.matrix(predict(fit, df, type = "prob")),
+    ignore_attr = TRUE
+  )
+})
+
+test_that("rule_fit() refuses a multiclass outcome", {
+  skip_if_no_xrf()
+
+  # xrf itself only fits `family = "gaussian"` and `family = "binomial"`, so
+  # there is nothing for orbital to translate. The refusal comes from upstream.
+  set.seed(123)
+  fit <- parsnip::fit(
+    parsnip::rule_fit(mode = "classification", trees = 5, penalty = 0.01),
+    Species ~ .,
+    iris
+  )
+
+  expect_snapshot(error = TRUE, orbital(fit, type = "class"))
+})
+
+test_that("rule_fit() works with a custom prefix", {
+  skip_if_no_xrf()
+
+  df <- xrf_data()
+  set.seed(123)
+  fit <- parsnip::fit(
+    parsnip::rule_fit(mode = "classification", trees = 5, penalty = 0.01),
+    Species ~ .,
+    df
+  )
+
+  preds <- predict(orbital(fit, type = "prob", prefix = "p"), df)
+
+  expect_named(preds, c("p_versicolor", "p_virginica"))
+})

--- a/vignettes/supported-models.Rmd
+++ b/vignettes/supported-models.Rmd
@@ -56,6 +56,7 @@ tibble::tribble(
   "`linear_reg()`",       "`\"glmnet\"`",       "✅",     "❌",    "❌",
   "`logistic_reg()`",     "`\"glm\"`",          "❌",     "✅",    "✅",
   "`logistic_reg()`",     "`\"glmnet\"`",       "❌",     "✅",    "✅",
+  "`logistic_reg()`",     "`\"LiblineaR\"`",    "❌",     "✅",    "✅",
   "`mars()`",             "`\"earth\"`",        "✅",     "✅",    "✅",
   "`mlp()`",              "`\"nnet\"`",         "✅",     "✅",    "✅",
   "`multinom_reg()`",     "`\"glmnet\"`",       "❌",     "✅",    "✅",
@@ -67,7 +68,10 @@ tibble::tribble(
   "`pls()`",              "`\"mixOmics\"`",     "✅",     "❌",    "✅",
   "`rand_forest()`",      "`\"partykit\"`",     "✅",     "❌",    "❌",
   "`rand_forest()`",      "`\"randomForest\"`", "✅",     "✅",    "✅",
-  "`rand_forest()`",      "`\"ranger\"`",       "✅",     "✅",    "✅"
+  "`rand_forest()`",      "`\"ranger\"`",       "✅",     "✅",    "✅",
+  "`rule_fit()`",         "`\"xrf\"`",          "✅",     "✅",    "✅",
+  "`svm_linear()`",       "`\"kernlab\"`",      "✅",     "✅",    "✅",
+  "`svm_linear()`",       "`\"LiblineaR\"`",    "✅",     "✅",    "❌"
 ) |>
   gt() |>
   tab_spanner(


### PR DESCRIPTION
Phase 4 tier 4 of the tidypredict backends plan, minus H2O.

## New models

| model | engine | numeric | class | prob |
|---|---|---|---|---|
| `svm_linear()` | kernlab | 8.9e-16 | 1.00 | 7.8e-16 |
| `svm_linear()` | LiblineaR | 1.8e-15 | 1.00 | refused (decision value) |
| `logistic_reg()` | LiblineaR | n/a | 1.00 | 8.9e-16 |
| `rule_fit()` | xrf | 8.9e-16 | 1.00 | 2.2e-16 |

Figures are max absolute difference against `predict()`, or class agreement. Multinomial `glmnet` was also on the tier list; it already worked through orbital's native method and is exact (1.6e-14), so nothing was needed. Multiclass `rule_fit()` is refused upstream, since xrf only fits Gaussian and binomial models.

## Two bugs, same shape

Both are cases where a binary class label was derived from a quantity the *model* orients, using the order of the outcome's factor levels.

**LiblineaR SVM class predictions were inverted.** `binary_from_decision()` assumed a positive decision value means the second level. LiblineaR orients it toward `ClassNames[1]`, which is the model's own class order. On `iris` minus setosa the measured class agreement was **0.00**: every row wrong. The existing test in `test-fallback-routing.R` passed only because its `no`/`yes` recoding happened to line the two orders up. `tidypredict_outcome_levels()` follows `lvl`, so it cannot supply the orientation, and `ClassNames` is read from the fit directly.

**kernlab SVM class predictions disagreed near the boundary.** kernlab classifies by the sign of the decision function but calibrates probabilities separately with Platt scaling, so the two rules cross at `1 / (1 + exp(B))`, not at 0.5. Agreement was 0.98, and the 2% was systematic rather than noise. Reading `B` off `@prob.model` restores it to 1.00. `binary_from_prob()` gains a `cut` argument, defaulting to 0.5 so no other backend changes.

Both orientations were verified against reversed outcome levels, which is what pulls `lvl` and the model's own order apart. Tests pin both.

## Follow-up

Both fixes reach into a fitted model for something tidypredict describes but does not expose. Filing an upstream issue proposing accessors for the decision orientation and the class threshold, at which point these two helpers become one call each.

`FAIL 0 | WARN 4 | SKIP 10 | PASS 1221`, up from 1200. Same 4 pre-existing YeoJohnson warnings and 10 skips as `main`.
