### PR TITLE
Add h2o GBM and RuleFit support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     generics (>= 0.1.2),
     rlang
 Suggests:
+    agua,
     arrow,
     baguette,
     bonsai,
@@ -36,6 +37,7 @@ Suggests:
     glmnet,
     glue,
     gt,
+    h2o,
     hardhat,
     jsonlite,
     kernlab,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * `boost_tree()` with the `"C5.0"` engine is now supported for `type = "class"`, including multi-trial boosting. (#161)
 
+* `boost_tree()` with the `"h2o_gbm"` engine, and `rule_fit()` with the `"h2o"` engine, are now supported for regression and classification. A running H2O cluster is needed to build the orbital object, but not to use one afterwards. (#166)
+
 * `C5_rules()` with the `"C5.0"` engine is now supported for `type = "class"`. (#161)
 
 * `discrim_linear()` and `discrim_quad()` with the `"MASS"` engine are now supported for `type = "class"` and `type = "prob"`. (#160)
@@ -43,6 +45,8 @@
 * `orbital()` refuses `type = "prob"` for models that have no probability to give, rather than fabricating one. A decision value is uncalibrated, so putting it through a logistic would invent a calibration the model does not have. (#159)
 
 ## Bug fixes
+
+* `orbital()` now uses the model's own class order for binary probabilities, rather than assuming it matches the order of the outcome's factor levels. Every engine but h2o orders them the same way, so only h2o models were affected, and only when the outcome's levels were not in sorted order; for those both probability columns were swapped and the class inverted. (#166)
 
 * `orbital()` now returns the correct classes for `svm_linear()` models with the `"LiblineaR"` engine. The sign of the decision value was read as meaning the second outcome level, but LiblineaR orients it by its own class order, which need not match the order of the outcome's factor levels. When the two disagreed every class was inverted. (#164)
 

--- a/R/classification-helpers.R
+++ b/R/classification-helpers.R
@@ -8,17 +8,18 @@ backtick <- function(x) {
 # Binary classification from a single probability expression
 # Assumes: eq is P(second level)
 #
-# `cut` is the probability above which the second level is chosen. It is 0.5 for
-# every model whose class rule is the larger of the two probabilities, but not
-# for one that calibrates a separate decision function; see `prob_class_cut()`.
-binary_from_prob <- function(eq, type, lvl, cut = 0.5) {
+# `cut` is the probability above which the second level is chosen, and `op` the
+# comparison used against it. Both are 0.5 and `>` for every model whose class
+# rule is the larger of the two probabilities, but not for one carrying its own
+# tuned threshold; see `prob_class_rule()`.
+binary_from_prob <- function(eq, type, lvl, cut = 0.5, op = ">") {
   res <- NULL
   if ("class" %in% type) {
     levels <- glue::double_quote(lvl)
     res <- c(
       res,
       orbital_tmp_class_name = glue::glue(
-        "dplyr::case_when({eq} > {format_numeric(cut)} ~ {levels[2]}, .default = {levels[1]})"
+        "dplyr::case_when({eq} {op} {format_numeric(cut)} ~ {levels[2]}, .default = {levels[1]})"
       )
     )
   }
@@ -34,14 +35,17 @@ binary_from_prob <- function(eq, type, lvl, cut = 0.5) {
 
 # Binary classification from a single probability expression
 # Assumes: eq is P(first level)
-binary_from_prob_first <- function(eq, type, lvl) {
+#
+# `cut` is the probability above which the first level is chosen, and `op` the
+# comparison used against it; see `binary_from_prob()`.
+binary_from_prob_first <- function(eq, type, lvl, cut = 0.5, op = ">") {
   res <- NULL
   if ("class" %in% type) {
     levels <- glue::double_quote(lvl)
     res <- c(
       res,
       orbital_tmp_class_name = glue::glue(
-        "dplyr::case_when({eq} > 0.5 ~ {levels[1]}, .default = {levels[2]})"
+        "dplyr::case_when({eq} {op} {format_numeric(cut)} ~ {levels[1]}, .default = {levels[2]})"
       )
     )
   }

--- a/R/fallback-routing.R
+++ b/R/fallback-routing.R
@@ -52,13 +52,16 @@ route_prob <- function(res, x, type, call) {
   abort_if_class_by_centroid(x, type, call)
 
   if (is.language(res)) {
-    # Binary: one expression giving the probability of the second level.
-    return(binary_from_prob(
-      deparse1(res, control = "digits17"),
-      type,
-      lvl,
-      prob_class_cut(x)
-    ))
+    # Binary: one expression giving the probability of a single level, which is
+    # the model's second level rather than necessarily parsnip's.
+    eq <- deparse1(res, control = "digits17")
+    rule <- prob_class_rule(x)
+
+    if (identical(binary_positive_level(x, lvl), lvl[2])) {
+      return(binary_from_prob(eq, type, lvl, rule$cut, rule$op))
+    }
+
+    return(binary_from_prob_first(eq, type, lvl, rule$cut, rule$op))
   }
 
   if (isFALSE(tidypredict::tidypredict_normalized(x$fit))) {
@@ -109,6 +112,26 @@ order_prob_eqs <- function(prob_eqs, x, lvl, call) {
   unname(stats::setNames(prob_eqs, model_levels)[lvl])
 }
 
+# Which level the single binary probability expression is for.
+#
+# Every backend but h2o orders its classes the way the outcome's factor levels
+# are ordered, making this `lvl[2]`. h2o sorts its own domain and keeps that
+# order regardless, so a model fitted on reversed levels still returns the
+# probability of what parsnip calls the first level. Taking it for the second
+# would swap both probability columns and invert the class.
+binary_positive_level <- function(x, lvl) {
+  model_levels <- tryCatch(
+    tidypredict::tidypredict_outcome_levels(x$fit),
+    error = function(e) NULL
+  )
+
+  if (length(model_levels) != 2 || !setequal(model_levels, lvl)) {
+    return(lvl[2])
+  }
+
+  model_levels[2]
+}
+
 # Which outcome level a positive decision value means.
 #
 # LiblineaR orients its decision function toward the first entry of
@@ -133,16 +156,38 @@ decision_positive_level <- function(x, call) {
   class_names[1]
 }
 
-# The probability above which the second level is predicted.
+# The rule turning the binary probability into a class: the threshold, and the
+# comparison made against it.
 #
-# 0.5 for every model that picks the larger of the two probabilities. kernlab
-# does not: it classifies by the sign of the decision function and calibrates
-# the probabilities separately with Platt scaling, so the two rules cross at
+# `0.5` and `>` for every model that picks the larger of the two probabilities.
+# Two do not.
+#
+# h2o chooses a threshold maximizing F1 on the training data and applies that
+# instead of 0.5, so its own labels can disagree with its own probabilities
+# across a wide band. On `iris` the F1 threshold came out at 0.90, putting a 0.5
+# cut at odds with the model on half the rows. It compares with `>=`, and since
+# the threshold it picks is an observed probability rather than an arbitrary
+# number, rows landing exactly on it are common rather than a curiosity.
+#
+# kernlab classifies by the sign of the decision function and calibrates the
+# probabilities separately with Platt scaling, so the two rules cross at
 # `1 / (1 + exp(B))` rather than at 0.5. With `iris` the difference moves 2% of
 # rows, all of them near the boundary.
-prob_class_cut <- function(x) {
+prob_class_rule <- function(x) {
+  default <- list(cut = 0.5, op = ">")
+
+  if (inherits(x$fit, "H2OBinomialModel")) {
+    threshold <- x$fit@model$default_threshold
+
+    if (!is.numeric(threshold) || length(threshold) != 1) {
+      return(default)
+    }
+
+    return(list(cut = threshold, op = ">="))
+  }
+
   if (!inherits(x$fit, "ksvm")) {
-    return(0.5)
+    return(default)
   }
 
   # An `ksvm()` fitted with `prob.model = FALSE` carries an empty list here, in
@@ -150,10 +195,10 @@ prob_class_cut <- function(x) {
   prob_model <- x$fit@prob.model
 
   if (length(prob_model) < 1 || !is.numeric(prob_model[[1]]$B)) {
-    return(0.5)
+    return(default)
   }
 
-  1 / (1 + exp(prob_model[[1]]$B))
+  list(cut = 1 / (1 + exp(prob_model[[1]]$B)), op = ">")
 }
 
 # mixOmics discriminant models assign a class by distance to the class centroid

--- a/tests/testthat/_snaps/model-h2o.md
+++ b/tests/testthat/_snaps/model-h2o.md
@@ -1,0 +1,9 @@
+# an unsupported h2o model is refused
+
+    Code
+      orbital(fit)
+    Condition
+      Error in `tidypredict_fit()`:
+      ! Only h2o GBM and RuleFit models are supported.
+      i This model was fit with "glm".
+

--- a/tests/testthat/helper-h2o.R
+++ b/tests/testthat/helper-h2o.R
@@ -1,0 +1,100 @@
+# Connect to (or start) a local H2O cluster for tests. Adapted from the
+# equivalent helper in tidypredict.
+#
+# H2O is noisy: `h2o.init()` prints a cluster banner and warns whenever the
+# running cluster is older than the newest release, and it reports a genuine
+# version mismatch between the cluster and the h2o R package as a warning rather
+# than an error. Neither is caught by `suppressMessages()` or
+# `tryCatch(error = )`, so they would surface as testthat warnings instead of
+# clean skips. Everything below is muffled, and any condition that means the
+# cluster is not usable turns into a skip.
+#
+# The probe is memoized so the cluster is started at most once per test run, and
+# shut down when the suite finishes.
+
+h2o_cluster_probe <- local({
+  status <- NULL
+
+  function() {
+    if (!is.null(status)) {
+      return(status)
+    }
+
+    mismatch <- NULL
+
+    status <<- tryCatch(
+      withCallingHandlers(
+        {
+          utils::capture.output(suppressMessages({
+            up <- isTRUE(try(h2o::h2o.clusterIsUp(), silent = TRUE))
+            if (!up) {
+              up <- tryCatch(
+                {
+                  h2o::h2o.connect()
+                  TRUE
+                },
+                error = function(e) FALSE
+              )
+            }
+            if (!up) {
+              h2o::h2o.init()
+              withr::defer(
+                try(h2o::h2o.shutdown(prompt = FALSE), silent = TRUE),
+                testthat::teardown_env()
+              )
+            }
+            h2o::h2o.no_progress()
+          }))
+
+          if (!is.null(mismatch)) {
+            mismatch
+          } else if (
+            !identical(
+              h2o::h2o.getVersion(),
+              as.character(packageVersion("h2o"))
+            )
+          ) {
+            paste0(
+              "H2O cluster version (",
+              h2o::h2o.getVersion(),
+              ") does not match the h2o R package version (",
+              packageVersion("h2o"),
+              ")."
+            )
+          } else {
+            "ok"
+          }
+        },
+        warning = function(w) {
+          msg <- conditionMessage(w)
+          if (grepl("version mismatch", msg, ignore.case = TRUE)) {
+            mismatch <<- paste0("H2O version mismatch: ", msg)
+          }
+          invokeRestart("muffleWarning")
+        }
+      ),
+      error = function(e) {
+        paste0("Could not start an H2O cluster: ", conditionMessage(e))
+      }
+    )
+
+    status
+  }
+})
+
+skip_if_no_h2o <- function() {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("parsnip")
+  testthat::skip_if_not_installed("tidypredict")
+  testthat::skip_if_not_installed("h2o")
+  testthat::skip_if_not_installed("agua")
+
+  if (!nzchar(Sys.which("java"))) {
+    testthat::skip("No Java runtime found; H2O needs a JVM.")
+  }
+
+  status <- h2o_cluster_probe()
+  if (!identical(status, "ok")) {
+    testthat::skip(status)
+  }
+}

--- a/tests/testthat/test-model-h2o.R
+++ b/tests/testthat/test-model-h2o.R
@@ -1,0 +1,166 @@
+h2o_two_species <- function(levels = c("versicolor", "virginica")) {
+  df <- iris[iris$Species != "setosa", ]
+  df$Species <- factor(as.character(df$Species), levels = levels)
+  df
+}
+
+# h2o picks a threshold that maximizes F1, and that threshold is one of the
+# probabilities it actually predicted. A row landing exactly on it is decided by
+# arithmetic orbital cannot reproduce bit for bit, since it recomputes the
+# probability from the translated expression. Such rows are excluded rather than
+# asserted on; everything either side of the threshold is exact.
+expect_class_agreement <- function(fit, data) {
+  orb <- as.character(predict(orbital(fit, type = "class"), data)[[1]])
+  own <- as.character(predict(fit, data, type = "class")$.pred_class)
+
+  threshold <- fit$fit@model$default_threshold
+  probs <- predict(fit, data, type = "prob")
+  decided <- abs(probs[[2]] - threshold) > 1e-9
+
+  expect_equal(orb[decided], own[decided])
+}
+
+test_that("boost_tree() works with type = numeric", {
+  skip_if_no_h2o()
+
+  fit <- parsnip::fit(
+    parsnip::boost_tree(mode = "regression", engine = "h2o_gbm", trees = 5),
+    Sepal.Length ~ .,
+    iris[, -5]
+  )
+
+  preds <- predict(orbital(fit), iris)
+
+  expect_named(preds, ".pred")
+  expect_equal(preds$.pred, predict(fit, iris)$.pred, tolerance = 1e-6)
+})
+
+test_that("boost_tree() works with type = class and type = prob", {
+  skip_if_no_h2o()
+
+  df <- h2o_two_species()
+  fit <- parsnip::fit(
+    parsnip::boost_tree(mode = "classification", engine = "h2o_gbm", trees = 5),
+    Species ~ .,
+    df
+  )
+
+  expect_class_agreement(fit, df)
+
+  preds <- predict(orbital(fit, type = "prob"), df)
+  expect_named(preds, c(".pred_versicolor", ".pred_virginica"))
+  expect_equal(
+    as.matrix(preds),
+    as.matrix(predict(fit, df, type = "prob")),
+    ignore_attr = TRUE,
+    tolerance = 1e-6
+  )
+})
+
+test_that("boost_tree() binary does not depend on the outcome's level order", {
+  skip_if_no_h2o()
+
+  # h2o sorts its own class domain and keeps that order however the outcome's
+  # factor levels are ordered, so the single probability it returns is not
+  # always the one for the second level, and its threshold applies to whichever
+  # level it did return.
+  df <- h2o_two_species(c("virginica", "versicolor"))
+  fit <- parsnip::fit(
+    parsnip::boost_tree(mode = "classification", engine = "h2o_gbm", trees = 5),
+    Species ~ .,
+    df
+  )
+
+  expect_class_agreement(fit, df)
+
+  preds <- predict(orbital(fit, type = "prob"), df)
+  expect_named(preds, c(".pred_virginica", ".pred_versicolor"))
+  expect_equal(
+    preds$.pred_virginica,
+    predict(fit, df, type = "prob")$.pred_virginica,
+    tolerance = 1e-6
+  )
+})
+
+test_that("boost_tree() works with a multiclass outcome", {
+  skip_if_no_h2o()
+
+  fit <- parsnip::fit(
+    parsnip::boost_tree(mode = "classification", engine = "h2o_gbm", trees = 5),
+    Species ~ .,
+    iris
+  )
+
+  expect_equal(
+    predict(orbital(fit, type = "class"), iris)$.pred_class,
+    as.character(predict(fit, iris, type = "class")$.pred_class)
+  )
+  expect_equal(
+    as.matrix(predict(orbital(fit, type = "prob"), iris)),
+    as.matrix(predict(fit, iris, type = "prob")),
+    ignore_attr = TRUE,
+    tolerance = 1e-6
+  )
+})
+
+test_that("rule_fit() works with type = numeric", {
+  skip_if_no_h2o()
+
+  fit <- parsnip::fit(
+    parsnip::rule_fit(mode = "regression", engine = "h2o", trees = 5),
+    Sepal.Length ~ .,
+    iris[, -5]
+  )
+
+  preds <- predict(orbital(fit), iris)
+
+  expect_named(preds, ".pred")
+  expect_equal(preds$.pred, predict(fit, iris)$.pred, tolerance = 1e-6)
+})
+
+test_that("rule_fit() works with type = class and type = prob", {
+  skip_if_no_h2o()
+
+  df <- h2o_two_species()
+  fit <- parsnip::fit(
+    parsnip::rule_fit(mode = "classification", engine = "h2o", trees = 5),
+    Species ~ .,
+    df
+  )
+
+  expect_class_agreement(fit, df)
+  expect_equal(
+    as.matrix(predict(orbital(fit, type = "prob"), df)),
+    as.matrix(predict(fit, df, type = "prob")),
+    ignore_attr = TRUE,
+    tolerance = 1e-6
+  )
+})
+
+test_that("h2o models work with a custom prefix", {
+  skip_if_no_h2o()
+
+  df <- h2o_two_species()
+  fit <- parsnip::fit(
+    parsnip::boost_tree(mode = "classification", engine = "h2o_gbm", trees = 5),
+    Species ~ .,
+    df
+  )
+
+  preds <- predict(orbital(fit, type = "prob", prefix = "p"), df)
+
+  expect_named(preds, c("p_versicolor", "p_virginica"))
+})
+
+test_that("an unsupported h2o model is refused", {
+  skip_if_no_h2o()
+
+  # tidypredict translates h2o GBM and RuleFit only.
+  fit <- parsnip::fit(
+    parsnip::linear_reg(engine = "h2o"),
+    Sepal.Length ~ .,
+    iris[, -5]
+  )
+
+  expect_snapshot(error = TRUE, orbital(fit))
+})

--- a/vignettes/supported-models.Rmd
+++ b/vignettes/supported-models.Rmd
@@ -39,6 +39,7 @@ tibble::tribble(
   "`bart()`",             "`\"dbarts\"`",       "✅",     "❌",    "❌",
   "`boost_tree()`",       "`\"C5.0\"`",         "❌",     "✅",    "❌",
   "`boost_tree()`",       "`\"catboost\"`",     "✅",     "✅",    "✅",
+  "`boost_tree()`",       "`\"h2o_gbm\"`",      "✅",     "✅",    "✅",
   "`boost_tree()`",       "`\"lightgbm\"`",     "✅",     "✅",    "✅",
   "`boost_tree()`",       "`\"xgboost\"`",      "✅",     "✅",    "✅",
   "`C5_rules()`",         "`\"C5.0\"`",         "❌",     "✅",    "❌",
@@ -69,6 +70,7 @@ tibble::tribble(
   "`rand_forest()`",      "`\"partykit\"`",     "✅",     "❌",    "❌",
   "`rand_forest()`",      "`\"randomForest\"`", "✅",     "✅",    "✅",
   "`rand_forest()`",      "`\"ranger\"`",       "✅",     "✅",    "✅",
+  "`rule_fit()`",         "`\"h2o\"`",          "✅",     "✅",    "✅",
   "`rule_fit()`",         "`\"xrf\"`",          "✅",     "✅",    "✅",
   "`svm_linear()`",       "`\"kernlab\"`",      "✅",     "✅",    "✅",
   "`svm_linear()`",       "`\"LiblineaR\"`",    "✅",     "✅",    "❌"


### PR DESCRIPTION
Closes out phase 4 tier 4 of the tidypredict backends plan. Best-effort and skip-guarded, per the scope call on H2O.

## Accuracy

| model | engine | numeric | class | prob |
|---|---|---|---|---|
| `boost_tree()` | h2o_gbm | 3.2e-08 | 1.00 | 1.3e-09 |
| `boost_tree()` multiclass | h2o_gbm | n/a | 1.00 | 1.3e-09 |
| `rule_fit()` | h2o | 2.7e-15 | 1.00 | 4.4e-15 |

Verified against a live local cluster. `linear_reg(engine = "h2o")` is refused upstream (tidypredict translates GBM and RuleFit only) and that refusal is snapshotted.

Note `boost_tree(engine = "h2o")` is H2O's *xgboost*, which is unavailable on macOS and is a separate backend; this PR covers `"h2o_gbm"`.

## Two shared assumptions h2o broke

h2o is the first backend whose class order is **its own** rather than the outcome's factor level order, and it was the only way to notice that two things in the binary probability path were assumptions rather than facts.

**The single probability expression was taken to be P(second level).** h2o sorts its domain and keeps that order however the outcome's levels are ordered. On reversed levels, orbital returned both probability columns swapped and the class inverted, silently. The level is now read from `tidypredict_outcome_levels()` when the model reports one. I checked seven existing binary backends (glm, glmnet, LiblineaR, earth, rpart, kernlab, MASS) and all report an order matching `lvl`, or none at all, so this is a no-op for every one of them. The full suite confirms it.

**The class cut was assumed to be 0.5.** h2o applies a threshold maximizing F1 on the training data, which came out at 0.90 here and disagreed with a 0.5 cut on **half** the rows. It also compares with `>=` rather than `>`, and since the threshold it picks is an observed predicted probability, rows landing exactly on it are ordinary rather than a curiosity. The threshold and the comparison now travel together as `prob_class_rule()`, which absorbs the kernlab Platt cut from #164 as well.

## One honest limitation

A row sitting *exactly* on the tuned threshold cannot be reproduced reliably: orbital recomputes the probability from the translated expression and lands within about 5e-15 of the threshold, which can fall either side of it. The tests exclude that knife edge and assert on everything else, rather than asserting a figure that would flake. Worth knowing rather than papering over.

## CI

`h2o` and `agua` go into Suggests. Neither pulls in `xgboost` or `mixOmics`, so neither defeats the existing `?ignore-before-r=` guards, which I checked given that exact failure has now happened twice. h2o's own dependencies are light; the install cost is the JAR download. Tests skip when there is no cluster, no JVM, no `h2o`, or a cluster/package version mismatch, using a guard adapted from tidypredict's.

`FAIL 0 | WARN 4 | SKIP 10 | PASS 1237`, up from 1221. Same pre-existing warnings and skips as `main`.
