### PR TITLE
Refuse to estimate a workflow whose model has no estimate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,8 @@
 
 ## Bug fixes
 
+* `estimate_orbital_size()` now errors for a workflow whose model it has no estimate for, rather than counting that model as zero characters and returning the recipe's size as the whole workflow's. The model is usually the bulk of the expression, so the number it returned could be off by orders of magnitude while looking ordinary, and it did not move as the model's hyperparameters changed. (#167)
+
 * `orbital()` now uses the model's own class order for binary probabilities, rather than assuming it matches the order of the outcome's factor levels. Every engine but h2o orders them the same way, so only h2o models were affected, and only when the outcome's levels were not in sorted order; for those both probability columns were swapped and the class inverted. (#166)
 
 * `orbital()` now returns the correct classes for `svm_linear()` models with the `"LiblineaR"` engine. The sign of the decision value was read as meaning the second outcome level, but LiblineaR orients it by its own class order, which need not match the order of the outcome's factor levels. When the two disagreed every class was inverted. (#164)

--- a/R/estimate-size.R
+++ b/R/estimate-size.R
@@ -25,8 +25,11 @@
 #' convert each tree to an R expression.
 #'
 #' This function aims to support all the same models and preprocessing
-#' operations as [orbital()]. If you find a case where `orbital()` works but
-#' `estimate_orbital_size()` does not, please
+#' operations as [orbital()], but does not yet reach all of them. A model with
+#' no estimate is an error rather than a zero, including inside a workflow,
+#' since a workflow's model is usually the bulk of the expression and counting
+#' it as free would report the recipe's size as the whole. If you find a case
+#' where `orbital()` works but `estimate_orbital_size()` does not, please
 #' [file an issue](https://github.com/tidymodels/orbital/issues).
 #'
 #' @seealso [orbital()] for generating orbital objects.
@@ -65,8 +68,13 @@ estimate_orbital_size <- function(x, ...) {
 #' @export
 estimate_orbital_size.default <- function(x, ...) {
   cli::cli_abort(
-    "{.fn estimate_orbital_size} is not implemented for
-    {.obj_type_friendly {x}}."
+    c(
+      "{.fn estimate_orbital_size} is not implemented for
+       {.obj_type_friendly {x}}.",
+      i = "Use {.fn orbital} to build the expression and measure it, or
+           {.url https://github.com/tidymodels/orbital/issues} to request an
+           estimate for this model."
+    )
   )
 }
 
@@ -372,16 +380,14 @@ estimate_orbital_size.workflow <- function(x, ...) {
     total_chars <- total_chars + estimate_orbital_size(recipe_fit, ...)
   }
 
-  # Estimate model contribution
+  # Estimate model contribution. An unsupported model is an error rather than a
+  # zero: the model is usually the bulk of the expression, so counting it as
+  # free reports the recipe's size as the whole workflow's. That number looks
+  # ordinary, which is what makes it worse than a refusal. It is also flat
+  # across hyperparameters, so tuning on it would compare candidates that the
+  # estimate cannot tell apart.
   model_fit <- workflows::extract_fit_parsnip(x)
-  model_chars <- tryCatch(
-    estimate_orbital_size(model_fit$fit, ...),
-    error = function(e) {
-      # Fall back to 0 if model type not supported
-      0L
-    }
-  )
-  total_chars <- total_chars + model_chars
+  total_chars <- total_chars + estimate_orbital_size(model_fit$fit, ...)
 
   # Estimate tailor contribution
   if ("tailor" %in% names(x$post$actions)) {

--- a/man/estimate_orbital_size.Rd
+++ b/man/estimate_orbital_size.Rd
@@ -78,8 +78,11 @@ orbital object because it only needs to inspect the tree structure, not
 convert each tree to an R expression.
 
 This function aims to support all the same models and preprocessing
-operations as \code{\link[=orbital]{orbital()}}. If you find a case where \code{orbital()} works but
-\code{estimate_orbital_size()} does not, please
+operations as \code{\link[=orbital]{orbital()}}, but does not yet reach all of them. A model with
+no estimate is an error rather than a zero, including inside a workflow,
+since a workflow's model is usually the bulk of the expression and counting
+it as free would report the recipe's size as the whole. If you find a case
+where \code{orbital()} works but \code{estimate_orbital_size()} does not, please
 \href{https://github.com/tidymodels/orbital/issues}{file an issue}.
 }
 \examples{

--- a/tests/testthat/_snaps/estimate-size.md
+++ b/tests/testthat/_snaps/estimate-size.md
@@ -5,6 +5,7 @@
     Condition
       Error in `estimate_orbital_size()`:
       ! `estimate_orbital_size()` is not implemented for a <POSIXct> object.
+      i Use `orbital()` to build the expression and measure it, or <https://github.com/tidymodels/orbital/issues> to request an estimate for this model.
 
 # estimate_orbital_size errors for glmnet with multiple lambdas
 
@@ -14,4 +15,22 @@
       Error in `estimate_orbital_size()`:
       ! glmnet model has multiple penalty values.
       i Specify a single `penalty` value.
+
+# estimate_orbital_size refuses a workflow whose model has no estimate
+
+    Code
+      estimate_orbital_size(wf)
+    Condition
+      Error in `estimate_orbital_size()`:
+      ! `estimate_orbital_size()` is not implemented for a <nnet.formula> object.
+      i Use `orbital()` to build the expression and measure it, or <https://github.com/tidymodels/orbital/issues> to request an estimate for this model.
+
+# estimate_orbital_size refuses a model it has no estimate for
+
+    Code
+      estimate_orbital_size(fit$fit)
+    Condition
+      Error in `estimate_orbital_size()`:
+      ! `estimate_orbital_size()` is not implemented for a <nnet.formula> object.
+      i Use `orbital()` to build the expression and measure it, or <https://github.com/tidymodels/orbital/issues> to request an estimate for this model.
 

--- a/tests/testthat/test-estimate-size.R
+++ b/tests/testthat/test-estimate-size.R
@@ -418,3 +418,35 @@ test_that("estimate_orbital_size for workflow combines recipe and model", {
   expect_gt(wf_est, actual * 0.5)
   expect_lt(wf_est, actual * 1.5)
 })
+
+test_that("estimate_orbital_size refuses a workflow whose model has no estimate", {
+  skip_if_not_installed("recipes")
+  skip_if_not_installed("workflows")
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("nnet")
+
+  rec <- recipes::recipe(mpg ~ ., data = mtcars) |>
+    recipes::step_normalize(recipes::all_numeric_predictors())
+
+  wf <- workflows::workflow() |>
+    workflows::add_recipe(rec) |>
+    workflows::add_model(
+      parsnip::mlp(mode = "regression", engine = "nnet", epochs = 10)
+    ) |>
+    parsnip::fit(mtcars)
+
+  expect_snapshot(error = TRUE, estimate_orbital_size(wf))
+})
+
+test_that("estimate_orbital_size refuses a model it has no estimate for", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("nnet")
+
+  fit <- parsnip::fit(
+    parsnip::mlp(mode = "regression", engine = "nnet", epochs = 10),
+    mpg ~ .,
+    mtcars
+  )
+
+  expect_snapshot(error = TRUE, estimate_orbital_size(fit$fit))
+})


### PR DESCRIPTION
`estimate_orbital_size.workflow()` wrapped the model's estimate in a `tryCatch` that returned `0L` on error, so a workflow whose model has no method reported the recipe's size as the whole workflow's.

That is the same shape as the bug fixed in #156: an error swallowed and replaced with a plausible-looking answer. It surfaces now because phase 4 added roughly 25 backends, none of which have an estimate method, so the path went from rare to routine.

Measured against the actual expression, with a `step_normalize()` recipe contributing 246 characters:

| model | estimate | actual |
|---|---|---|
| `boost_tree()` C5.0 | 246 | 192,837 |
| `mlp()` nnet | 246 | 143,823 |
| `bag_tree()` rpart | 246 | 92,168 |
| `discrim_linear()` MASS | 246 | 2,554 |
| `multinom_reg()` nnet | 246 | 1,853 |

The number looks ordinary, which is what makes it worse than a refusal. It is also flat across hyperparameters, so the tuning use the function is documented for (`control_grid(extract = estimate_orbital_size)`) would compare candidates the estimate cannot tell apart.

The error now propagates. The default method's message gains two pointers: use `orbital()` and measure, or file an issue to request an estimate. The docs no longer imply coverage matches `orbital()`.

This is a behavior change for anyone calling `estimate_orbital_size()` on a workflow with an unsupported model: they go from a wrong number to an error. The function's own docs already stated the refusal contract ("If you find a case where `orbital()` works but `estimate_orbital_size()` does not, please file an issue"), so the zero was never the intended answer.

Supported models are unaffected: no error is raised for them, and the vignette's tuning example uses xgboost.

Cross-reference: phase 5 of the backends plan, the item asking that new classes get a sensible refusal or estimate rather than a wrong number.

## Not in this PR

The plan also asks for estimate methods for C5.0, cforest, and bart "where cheap". None of the three is cheap, so they are left out rather than guessed at:

- **C5.0** is superlinear in the boosted multiclass vote: ~1,678 characters per internal node for a single tree, ~11,220 once boosting is on.
- **bart** is dominated by posterior draws, at 978k characters for 5 trees.
- **cforest** is clean and linear (822, 778, 756 characters per tree at 5, 10, 25 trees), but the existing shared tree formula lands 34% low on it (2,695 predicted against 4,110 actual), so it needs its own constants.

Each needs constants fitted across several datasets to meet the documented "within 5-10%" claim. Fitting them to one dataset would reintroduce the wrong number this PR removes. They also belong in a separate PR under the plan's rule that no PR mixes changing existing output with adding new output.

## Test plan

- Two new tests, one for the workflow path and one for a bare fit, both snapshotting the refusal.
- Full suite: `FAIL 0 | WARN 4 | SKIP 10 | PASS 1239`, up 2 from the new tests, with the same 4 pre-existing YeoJohnson warnings.
