### PR TITLE
Cover the new binary expression shapes in the round-trip tests

### DIFF
--- a/tests/testthat/_snaps/dt.md
+++ b/tests/testthat/_snaps/dt.md
@@ -31,3 +31,17 @@
     Output
       copy(`_DT`)[, `:=`(c("setosa", "versicolor", "virginica", ".pred_setosa", ".pred_versicolor", ".pred_virginica", ".pred_class"), { setosa <- 1/(1 + exp(-2.021974 + (Sepal.Length * -1.531199) + (Sepal.Width * -4.376043) + (Petal.Length * 4.695665) + (Petal.Width * 3.062585) - (-15.47784 + (Sepal.Length * 6.314758) + (Sepal.Width * 12.13932) + (Petal.Length * -16.94642) + (Petal.Width * -20.77005))) + exp(-33.53769 + (Sepal.Length * -4.783559) + (Sepal.Width * -7.763274) + (Petal.Length * 12.25076) + (Petal.Width * 17.70747) - (-15.47784 + (Sepal.Length * 6.314758) + (Sepal.Width * 12.13932) + (Petal.Length * -16.94642) + (Petal.Width * -20.77005)))) versicolor <- 1/(exp(-15.47784 + (Sepal.Length * 6.314758) + (Sepal.Width * 12.13932) + (Petal.Length * -16.94642) + (Petal.Width * -20.77005) - (-2.021974 + (Sepal.Length * -1.531199) + (Sepal.Width * -4.376043) + (Petal.Length * 4.695665) + (Petal.Width * 3.062585))) + 1 + exp(-33.53769 + (Sepal.Length * -4.783559) + (Sepal.Width * -7.763274) + (Petal.Length * 12.25076) + (Petal.Width * 17.70747) - (-2.021974 + (Sepal.Length * -1.531199) + (Sepal.Width * -4.376043) + (Petal.Length * 4.695665) + (Petal.Width * 3.062585)))) virginica <- 1/(exp(-15.47784 + (Sepal.Length * 6.314758) + (Sepal.Width * 12.13932) + (Petal.Length * -16.94642) + (Petal.Width * -20.77005) - (-33.53769 + (Sepal.Length * -4.783559) + (Sepal.Width * -7.763274) + (Petal.Length * 12.25076) + (Petal.Width * 17.70747))) + exp(-2.021974 + (Sepal.Length * -1.531199) + (Sepal.Width * -4.376043) + (Petal.Length * 4.695665) + (Petal.Width * 3.062585) - (-33.53769 + (Sepal.Length * -4.783559) + (Sepal.Width * -7.763274) + (Petal.Length * 12.25076) + (Petal.Width * 17.70747))) + 1) .pred_setosa <- setosa .pred_versicolor <- versicolor .pred_virginica <- virginica .pred_class <- fcase(setosa >= versicolor & setosa >= virginica, "setosa", versicolor >= setosa & versicolor >= virginica, "versicolor", rep(TRUE, .N), "virginica") .(setosa, versicolor, virginica, .pred_setosa, .pred_versicolor, .pred_virginica, .pred_class) })]
 
+# dt works for a binary decision value
+
+    Code
+      orbital_dt(obj)
+    Output
+      copy(`_DT`)[, `:=`(.pred_class = fcase(1.70829 + (Sepal.Length * 0.8510269) + (Sepal.Width * 0.986845) + (Petal.Length * -1.380919) + (Petal.Width * -1.865502) > 0, "versicolor", rep(TRUE, .N), "virginica"))]
+
+# dt works for a binary probability cut away from 0.5
+
+    Code
+      orbital_dt(obj)
+    Output
+      copy(`_DT`)[, `:=`(c(".pred_class", ".pred_versicolor", ".pred_virginica"), { .pred_class <- fcase(1/(1 + exp(-(-14.71509 + (Sepal.Length * -1.074479) + (Sepal.Width * -2.9855) + (Petal.Length * 3.688835) + (Petal.Width * 7.278738)))) > 0.4330417, "virginica", rep(TRUE, .N), "versicolor") .pred_versicolor <- 1 - (1/(1 + exp(-(-14.71509 + (Sepal.Length * -1.074479) + (Sepal.Width * -2.9855) + (Petal.Length * 3.688835) + (Petal.Width * 7.278738))))) .pred_virginica <- 1 - .pred_versicolor .(.pred_class, .pred_versicolor, .pred_virginica) })]
+

--- a/tests/testthat/_snaps/sql.md
+++ b/tests/testthat/_snaps/sql.md
@@ -97,3 +97,25 @@
       ELSE 'virginica'
       END AS .pred_class
 
+# sql works for a binary decision value
+
+    Code
+      orbital_sql(obj, con)
+    Output
+      <SQL> CASE
+      WHEN (((((1.70829 + ("Sepal.Length" * 0.8510269)) + ("Sepal.Width" * 0.986845)) + ("Petal.Length" * -1.380919)) + ("Petal.Width" * -1.865502)) > 0) THEN 'versicolor'
+      ELSE 'virginica'
+      END AS .pred_class
+
+# sql works for a binary probability cut away from 0.5
+
+    Code
+      orbital_sql(obj, con)
+    Output
+      <SQL> CASE
+      WHEN ((1 / (1 + EXP(-((((-14.71509 + ("Sepal.Length" * -1.074479)) + ("Sepal.Width" * -2.9855)) + ("Petal.Length" * 3.688835)) + ("Petal.Width" * 7.278738))))) > 0.4330417) THEN 'virginica'
+      ELSE 'versicolor'
+      END AS .pred_class
+      <SQL> 1 - (1 / (1 + EXP(-((((-14.71509 + ("Sepal.Length" * -1.074479)) + ("Sepal.Width" * -2.9855)) + ("Petal.Length" * 3.688835)) + ("Petal.Width" * 7.278738))))) AS .pred_versicolor
+      <SQL> 1 - ".pred_versicolor" AS .pred_virginica
+

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -42,3 +42,16 @@ flatten_query <- function(x) {
   x <- gsub("`_DT[0-9]+`", "`_DT`", pretty_print(x))
   gsub("\\s+", " ", paste(x, collapse = " "))
 }
+
+## The two non-setosa iris species, as a two-level outcome.
+##
+## Deliberately not named `binary_iris()`: two test files define a top-level
+## function by that name and they do not mean the same thing, one recoding
+## setosa against the rest and the other dropping setosa. They do not collide
+## because each file gets its own environment, but a shared helper reusing the
+## name would.
+two_species_iris <- function(levels = c("versicolor", "virginica")) {
+  df <- iris[iris$Species != "setosa", ]
+  df$Species <- factor(as.character(df$Species), levels = levels)
+  df
+}

--- a/tests/testthat/test-dt.R
+++ b/tests/testthat/test-dt.R
@@ -45,3 +45,41 @@ test_that("dt works for lda multiclass", {
     orbital_dt(obj)
   )
 })
+
+test_that("dt works for a binary decision value", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("dtplyr")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("LiblineaR")
+
+  # LiblineaR's solver is seeded from R's RNG, so its coefficients move between
+  # runs and the snapshot would not be stable without this.
+  set.seed(123)
+  spec <- parsnip::svm_linear(mode = "classification", engine = "LiblineaR")
+  fit <- parsnip::fit(spec, Species ~ ., two_species_iris())
+
+  obj <- orbital(fit, type = "class")
+
+  expect_snapshot(
+    transform = flatten_query,
+    orbital_dt(obj)
+  )
+})
+
+test_that("dt works for a binary probability cut away from 0.5", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("dtplyr")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("kernlab")
+
+  set.seed(123)
+  spec <- parsnip::svm_linear(mode = "classification", engine = "kernlab")
+  fit <- parsnip::fit(spec, Species ~ ., two_species_iris())
+
+  obj <- orbital(fit, type = c("class", "prob"))
+
+  expect_snapshot(
+    transform = flatten_query,
+    orbital_dt(obj)
+  )
+})

--- a/tests/testthat/test-json.R
+++ b/tests/testthat/test-json.R
@@ -182,3 +182,48 @@ test_that("json round-trip works for lda multiclass", {
 
   expect_identical(new, orbital_obj)
 })
+
+test_that("json round-trip works for a binary decision value", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("jsonlite")
+  skip_if_not_installed("LiblineaR")
+
+  set.seed(123)
+  spec <- parsnip::svm_linear(mode = "classification", engine = "LiblineaR")
+  fit <- parsnip::fit(spec, Species ~ ., two_species_iris())
+
+  orbital_obj <- orbital(fit, type = "class")
+
+  tmp_file <- tempfile()
+  orbital_json_write(orbital_obj, tmp_file)
+  new <- orbital_json_read(tmp_file)
+
+  expect_identical(new, orbital_obj)
+})
+
+test_that("json round-trip preserves a probability cut away from 0.5", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("jsonlite")
+  skip_if_not_installed("kernlab")
+
+  # The threshold kernlab implies is a full precision double rather than 0.5.
+  # Rounding it on the way through JSON would move rows across the cut, which
+  # is the failure that made tidypredict add its own save and load functions.
+  set.seed(123)
+  spec <- parsnip::svm_linear(mode = "classification", engine = "kernlab")
+  fit <- parsnip::fit(spec, Species ~ ., two_species_iris())
+
+  orbital_obj <- orbital(fit, type = c("class", "prob"))
+
+  tmp_file <- tempfile()
+  orbital_json_write(orbital_obj, tmp_file)
+  new <- orbital_json_read(tmp_file)
+
+  expect_identical(new, orbital_obj)
+  expect_identical(
+    predict(new, two_species_iris()),
+    predict(orbital_obj, two_species_iris())
+  )
+})

--- a/tests/testthat/test-sql.R
+++ b/tests/testthat/test-sql.R
@@ -158,3 +158,47 @@ test_that("sql works for lda multiclass", {
     orbital_sql(obj, con)
   )
 })
+
+test_that("sql works for a binary decision value", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("dbplyr")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("LiblineaR")
+
+  # LiblineaR's solver is seeded from R's RNG, so its coefficients move between
+  # runs and the snapshot would not be stable without this.
+  set.seed(123)
+  spec <- parsnip::svm_linear(mode = "classification", engine = "LiblineaR")
+  fit <- parsnip::fit(spec, Species ~ ., two_species_iris())
+
+  obj <- orbital(fit, type = "class")
+
+  con <- dbplyr::simulate_dbi()
+
+  expect_snapshot(
+    transform = orbital:::pretty_print,
+    orbital_sql(obj, con)
+  )
+})
+
+test_that("sql works for a binary probability cut away from 0.5", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("dbplyr")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("kernlab")
+
+  # kernlab carries its own cut, so the threshold in the query is a full
+  # precision literal rather than the 0.5 every other binary model uses.
+  set.seed(123)
+  spec <- parsnip::svm_linear(mode = "classification", engine = "kernlab")
+  fit <- parsnip::fit(spec, Species ~ ., two_species_iris())
+
+  obj <- orbital(fit, type = c("class", "prob"))
+
+  con <- dbplyr::simulate_dbi()
+
+  expect_snapshot(
+    transform = orbital:::pretty_print,
+    orbital_sql(obj, con)
+  )
+})


### PR DESCRIPTION
The SQL, data.table, and JSON round-trip tests reached the multiclass adapter through lda, but not the two expression shapes phase 4 added:

- the decision-value `case_when` that LiblineaR produces, where the cut is at 0 rather than 0.5 and no probability is emitted
- a probability cut somewhere other than 0.5, which kernlab produces because it classifies by decision sign and Platt-calibrates separately

The second is the one worth pinning. The cut is a full-precision double embedded as a literal:

```
dplyr::case_when(1/(1 + exp(-(-14.715093493792631 + ...))) > 0.4330417217823847 ~ "virginica", .default = "versicolor")
```

Rounding `0.4330417217823847` on the way through JSON would move rows across the threshold. That is exactly the failure that made tidypredict add `tidypredict_save()`/`tidypredict_load()`, and the plan flags it as a thing to check rather than assume. It survives intact, byte for byte, and there is now a test saying so rather than a one-off measurement.

All three round-trips execute cleanly for both shapes, so nothing needed fixing here. This is the verification turned into standing coverage.

## Two things found along the way

**LiblineaR's fits are not reproducible without a seed.** Its solver draws from R's RNG, so the first coefficient came out as `1.708386`, `1.708228`, and `1.7087675` across three runs of the same fit. The new snapshots would have been flaky. Both LiblineaR fits are now seeded, and I confirmed stability by regenerating twice and getting no snapshot churn on the second run. The existing `test-model-LiblineaR.R` tests are unaffected: they compare orbital against `predict()` on the same fitted object, so non-determinism cancels.

**`binary_iris()` means two different things.** `test-fallback-routing.R` defines it as setosa against the rest across all 150 rows; `test-model-C50.R` defines it as the 100 non-setosa rows. Both are top-level, and they do not collide only because testthat gives each file its own environment. Rather than reuse that name in a shared helper, this adds `two_species_iris()` to `helper-utils.R` with a comment saying why. The two existing definitions are left alone; renaming them is not this PR's business.

Cross-reference: phase 5 of the backends plan, the SQL, data.table, and JSON round-trip items.

## Test plan

- 7 new tests across `test-sql.R`, `test-dt.R`, and `test-json.R`.
- Full suite: `FAIL 0 | WARN 4 | SKIP 10 | PASS 1244`, up 7, with the same 4 pre-existing YeoJohnson warnings.
- Snapshots regenerated twice to confirm the seeds pin them.
