### PR TITLE
Document separate_trees scope and the class/probability split

### DIFF
--- a/vignettes/separate-trees.Rmd
+++ b/vignettes/separate-trees.Rmd
@@ -102,7 +102,25 @@ The `separate_trees` argument works with the following tree ensemble models:
 | `rand_forest()` | ranger | Yes | Yes |
 | `rand_forest()` | randomForest | Yes | Yes |
 
-For single-tree models like `decision_tree()`, the argument has no effect since there is only one tree. For multiclass classification, trees are separated per class before the final softmax transformation is applied.
+For multiclass classification, trees are separated per class before the final softmax transformation is applied.
+
+### Models where the argument has no effect
+
+`separate_trees` is accepted by `orbital()` for every model, but only the five above act on it. Everything else silently produces the same single combined expression it would have produced with the default. Setting it is never an error and never changes the predictions, so a query that looks unchanged is the expected result rather than a sign something went wrong.
+
+This is worth knowing because several supported models are tree ensembles that nonetheless ignore it:
+
+| Model | Engine | Why |
+|-------|--------|-----|
+| `bag_tree()` | rpart, C5.0 | Votes over the ensemble rather than summing it |
+| `bart()` | dbarts | Sums over posterior draws, not over separable trees |
+| `boost_tree()` | C5.0 | Confidence-weighted vote that cannot be recombined arithmetically |
+| `C5_rules()` | C5.0 | As above |
+| `rand_forest()` | partykit | Not yet wired up; the underlying model could support it |
+| `rule_fit()` | xrf, h2o | Emitted as a rule set rather than as individual trees |
+| `boost_tree()` | h2o_gbm | Translated through h2o's own export, which does not expose per-tree pieces |
+
+For single-tree models like `decision_tree()`, the argument has no effect for the simpler reason that there is only one tree to separate.
 
 ## Output behavior
 

--- a/vignettes/supported-models.Rmd
+++ b/vignettes/supported-models.Rmd
@@ -103,6 +103,18 @@ tibble::tribble(
   )
 ```
 
+### Why some models support one classification type but not the other
+
+The two classification columns are separate because not every model produces both, and orbital refuses a type rather than inventing it.
+
+**Class without probability.** Some models predict a label directly and never compute a probability at all. `bag_tree()` and `boost_tree()` with the `"C5.0"` engine, `C5_rules()`, and `bag_tree()` with `"rpart"` all reach their answer by voting across an ensemble; the vote yields a winner, not a distribution. `svm_linear()` with `"LiblineaR"` produces a *decision value*, the signed distance from the separating hyperplane. Its sign gives the class, but its magnitude is uncalibrated: it is not a probability and does not become one by being passed through a logistic. Doing that would attach a confidence the model never estimated, so `type = "prob"` is refused for all of these.
+
+**Probability without class.** `pls()` with `"mixOmics"` is the reverse case. It gives per-level values, but mixOmics assigns a class by distance to the class centroid rather than by taking the largest of those values, so the obvious `which.max()` would disagree with the model on some rows. orbital gives the probabilities and refuses `type = "class"`.
+
+**Both, but the cut is not 0.5.** `svm_linear()` with `"kernlab"` supports both, with a wrinkle worth knowing about. kernlab classifies by the sign of its decision function and fits its probabilities separately, using Platt scaling. The two rules do not cross at 0.5, so orbital emits kernlab's own threshold as a literal in the expression. If you compare orbital's `.pred_class` against thresholding its `.pred_*` columns at 0.5 yourself, expect disagreement on rows near the boundary; orbital matches the model, and 0.5 does not.
+
+The general rule: where a model's own prediction rule and the naive rule disagree, orbital follows the model.
+
 ## Recipes steps
 
 ```{r}


### PR DESCRIPTION
Phase 6 documentation, orbital side. Two gaps that phase 4 opened and nothing has closed yet.

## `separate_trees` is silently ignored by most models

The argument is accepted by `orbital()` for every model, but only xgboost, lightgbm, catboost, ranger and randomForest act on it. Everything else returns the same single combined expression as the default: no error, no warning, no change in predictions.

That was fine when the only other models were single-tree ones, where "no effect" is obvious. Phase 4 added several genuine tree ensembles that also ignore it, which is not obvious at all. Verified by measuring `length(orbital(fit, separate_trees = TRUE))` against the default:

| Model | default | `separate_trees = TRUE` |
|---|---|---|
| `rand_forest()` ranger | 1 | 6 |
| `bart()` dbarts | 1 | 1 |
| `boost_tree()` C5.0 | 1 | 1 |
| `rand_forest()` partykit | 1 | 1 |
| `rule_fit()` xrf | 1 | 1 |

The vignette now names these and gives the reason for each, so a user who sets the argument and sees an unchanged query knows that is the expected result.

One of these is an opportunity rather than a limitation: `partykit::cforest` **does** have a `tidypredict_trees()` method upstream, and it combines as a plain mean, so it is the one entry in that table that could be wired up. Not done here, since this PR is documentation only. Documented as "not yet wired up" rather than "cannot".

## Probabilities versus decision values

The supported-models table has separate class and prob columns, but never said why a model might have one and not the other. Added a section covering the three shapes phase 4 introduced:

- **Class without probability**: ensemble votes (C5.0, baguette) and LiblineaR decision values. A decision value's sign gives the class but its magnitude is uncalibrated, so `type = "prob"` is refused rather than run through a logistic that would invent a confidence.
- **Probability without class**: mixOmics PLS, whose class rule is centroid distance rather than the argmax of the values it reports.
- **Both, cut away from 0.5**: kernlab, which classifies by decision sign and Platt-calibrates separately. Measured on binary iris: the implied threshold is 0.4441, and 2 of 100 rows disagree with a naive 0.5 cut. orbital matches the model on all 100.

## Checks

- Both vignettes render.
- `pkgdown::check_pkgdown()` reports no problems, so no new topics are missing from `_pkgdown.yml`.
- No NEWS bullet: this documents existing behavior rather than changing any, per the repo convention.

Documentation only, no code or test changes.
