### PR TITLE
Write numbers as the shortest decimal R reads back unchanged

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,8 @@
 
 ## Bug fixes
 
+* `orbital()` now writes each number as the shortest decimal that R reads back unchanged, rather than always using 17 significant digits. R's decimal parser is not correctly rounded, so a 17-digit literal can be read back one ulp away from the value it came from. That is invisible in a linear predictor, but a tree whose cutpoints sit on values realized by training rows can send a row down the other branch, changing its prediction outright. The equations are also shorter and easier to read. (#165)
+
 * `estimate_orbital_size()` now errors for a workflow whose model it has no estimate for, rather than counting that model as zero characters and returning the recipe's size as the whole workflow's. The model is usually the bulk of the expression, so the number it returned could be off by orders of magnitude while looking ordinary, and it did not move as the model's hyperparameters changed. (#167)
 
 * `orbital()` now uses the model's own class order for binary probabilities, rather than assuming it matches the order of the outcome's factor levels. Every engine but h2o orders them the same way, so only h2o models were affected, and only when the outcome's levels were not in sorted order; for those both probability columns were swapped and the class inverted. (#166)

--- a/NEWS.md
+++ b/NEWS.md
@@ -46,7 +46,7 @@
 
 ## Bug fixes
 
-* `orbital()` now writes each number as the shortest decimal that R reads back unchanged, rather than always using 17 significant digits. R's decimal parser is not correctly rounded, so a 17-digit literal can be read back one ulp away from the value it came from. That is invisible in a linear predictor, but a tree whose cutpoints sit on values realized by training rows can send a row down the other branch, changing its prediction outright. The equations are also shorter and easier to read. (#165)
+* `orbital()` now writes each number as the shortest decimal that R reads back unchanged, rather than always using 17 significant digits. R's decimal parser is not correctly rounded, so a 17-digit literal can be read back one ulp away from the value it came from. That is invisible in a linear predictor, but a tree whose cutpoints sit on values realized by training rows can send a row down the other branch, changing its prediction outright. The equations are also shorter and easier to read. Some values no decimal literal reaches at all, so a residual difference remains for models that split on a computed value; this is described under "Numeric precision" in `?orbital`. (#165)
 
 * `estimate_orbital_size()` now errors for a workflow whose model it has no estimate for, rather than counting that model as zero characters and returning the recipe's size as the whole workflow's. The model is usually the bulk of the expression, so the number it returned could be off by orders of magnitude while looking ordinary, and it did not move as the model's hyperparameters changed. (#167)
 

--- a/R/classification-helpers.R
+++ b/R/classification-helpers.R
@@ -202,7 +202,6 @@ collapse_stumps <- function(x) {
 
 # Sum tree expressions for each class
 # Used by ranger and randomForest for classification
-# Uses digits17 control to preserve full numeric precision in split values
 sum_tree_expressions <- function(class_trees) {
   vapply(
     names(class_trees),
@@ -210,7 +209,7 @@ sum_tree_expressions <- function(class_trees) {
       trees <- class_trees[[cls]]
       tree_strs <- vapply(
         trees,
-        function(e) deparse1(e, control = "digits17"),
+        deparse_exact,
         character(1)
       )
       paste0("(", tree_strs, ")", collapse = " + ")
@@ -366,7 +365,7 @@ format_separate_trees <- function(trees, prefix = ".pred", batch_size = 50) {
 
   tree_strs <- vapply(
     trees,
-    function(e) deparse1(e, control = "digits17"),
+    deparse_exact,
     character(1)
   )
 

--- a/R/fallback-routing.R
+++ b/R/fallback-routing.R
@@ -54,7 +54,7 @@ route_prob <- function(res, x, type, call) {
   if (is.language(res)) {
     # Binary: one expression giving the probability of a single level, which is
     # the model's second level rather than necessarily parsnip's.
-    eq <- deparse1(res, control = "digits17")
+    eq <- deparse_exact(res)
     rule <- prob_class_rule(x)
 
     if (identical(binary_positive_level(x, lvl), lvl[2])) {
@@ -248,7 +248,7 @@ deparse_eq <- function(res, x, call) {
     )
   }
 
-  deparse1(res, control = "digits17")
+  deparse_exact(res)
 }
 
 abort_unsupported_output <- function(x, call) {

--- a/R/model-catboost.R
+++ b/R/model-catboost.R
@@ -59,7 +59,7 @@ catboost_multiclass <- function(x, type, lvl, separate_trees, prefix) {
       function(trees) {
         tree_strs <- vapply(
           trees,
-          function(e) deparse1(e, control = "digits17"),
+          deparse_exact,
           character(1)
         )
         paste(tree_strs, collapse = " + ")
@@ -75,7 +75,7 @@ catboost_multiclass <- function(x, type, lvl, separate_trees, prefix) {
 catboost_binary <- function(x, type, lvl, separate_trees, prefix) {
   if (!separate_trees) {
     eq <- tidypredict::tidypredict_fit(x)
-    eq <- deparse1(eq, control = "digits17")
+    eq <- deparse_exact(eq)
     return(binary_from_prob(eq, type, lvl))
   }
 

--- a/R/model-earth.R
+++ b/R/model-earth.R
@@ -20,7 +20,7 @@ orbital.earth <- function(
     } else {
       # Binary classification - tidypredict_fit returns P(second level)
       eq <- tidypredict::tidypredict_fit(x)
-      eq <- deparse1(eq, control = "digits17")
+      eq <- deparse_exact(eq)
 
       res <- binary_from_prob(eq, type, lvl)
     }

--- a/R/model-glm.R
+++ b/R/model-glm.R
@@ -16,7 +16,7 @@ orbital.glm <- function(
     }
 
     eq <- tidypredict::tidypredict_fit(x)
-    eq <- deparse1(eq, control = "digits17")
+    eq <- deparse_exact(eq)
 
     res <- binary_from_prob(eq, type, lvl)
   } else if (mode == "regression") {

--- a/R/model-lightgbm.R
+++ b/R/model-lightgbm.R
@@ -41,7 +41,7 @@ lightgbm_regression <- function(x, separate_trees, prefix) {
 lightgbm_binary <- function(x, type, lvl, separate_trees, prefix) {
   if (!separate_trees) {
     eq <- tidypredict::tidypredict_fit(x)
-    eq <- deparse1(eq, control = "digits17")
+    eq <- deparse_exact(eq)
     return(binary_from_prob(eq, type, lvl))
   }
 
@@ -74,7 +74,7 @@ lightgbm_multiclass <- function(x, type, lvl, separate_trees, prefix) {
       function(trees) {
         tree_strs <- vapply(
           trees,
-          function(e) deparse1(e, control = "digits17"),
+          deparse_exact,
           character(1)
         )
         paste(tree_strs, collapse = " + ")

--- a/R/model-partykit.R
+++ b/R/model-partykit.R
@@ -13,7 +13,7 @@ orbital.constparty <- function(
     res <- character()
     if ("class" %in% type) {
       eq <- tidypredict::tidypredict_fit(x)
-      eq <- deparse1(eq, control = "digits17")
+      eq <- deparse_exact(eq)
       res <- c(res, orbital_tmp_class_name = eq)
     }
     if ("prob" %in% type) {

--- a/R/model-rpart.R
+++ b/R/model-rpart.R
@@ -13,7 +13,7 @@ orbital.rpart <- function(
     res <- character()
     if ("class" %in% type) {
       eq <- tidypredict::tidypredict_fit(x)
-      eq <- deparse1(eq, control = "digits17")
+      eq <- deparse_exact(eq)
       res <- c(res, orbital_tmp_class_name = eq)
     }
     if ("prob" %in% type) {

--- a/R/model-xgboost.R
+++ b/R/model-xgboost.R
@@ -71,7 +71,7 @@ xgboost_multisoft <- function(x, type, lvl, separate_trees, prefix) {
       function(trees) {
         tree_strs <- vapply(
           trees,
-          function(e) deparse1(e, control = "digits17"),
+          deparse_exact,
           character(1)
         )
         paste(tree_strs, collapse = " + ")
@@ -87,7 +87,7 @@ xgboost_multisoft <- function(x, type, lvl, separate_trees, prefix) {
 xgboost_logistic <- function(x, type, lvl, separate_trees, prefix) {
   if (!separate_trees) {
     eq <- tidypredict::tidypredict_fit(x)
-    eq <- deparse1(eq, control = "digits17")
+    eq <- deparse_exact(eq)
     return(binary_from_prob_first(eq, type, lvl))
   }
 

--- a/R/orbital.R
+++ b/R/orbital.R
@@ -43,6 +43,26 @@
 #' [predict()][predict.orbital_class] with, or to generate code using functions
 #' such as [orbital_sql()] or [orbital_dt()].
 #'
+#' @section Numeric precision:
+#' An orbital object holds its equations as text, so every number a model
+#' carries is written out as a decimal and read back when the object is used.
+#' R's decimal parser is not correctly rounded, and for some values no decimal
+#' literal reads back to exactly the number the model produced. orbital writes
+#' the shortest decimal that does read back unchanged, and the closest decimal
+#' otherwise, so a coefficient can end up one unit in the last place away from
+#' the fitted value.
+#'
+#' For nearly every model that is orders of magnitude below the model's own
+#' uncertainty and can be ignored. It matters for trees that split on a value
+#' computed from several columns rather than on a raw column, such as the
+#' oblique forests of `rand_forest()` with the `"aorsf"` engine. Those splits
+#' are placed at combinations realized by training rows, so the comparison at a
+#' split is an exact tie for many rows, and the smallest possible difference is
+#' enough to send a row down the other branch. Its prediction then moves by the
+#' distance between two leaves rather than by a rounding error, and predictions
+#' can differ from `predict()` on the original fit for a meaningful share of
+#' rows.
+#'
 #' @examplesIf rlang::is_installed(c("recipes", "tidypredict", "workflows"))
 #' library(workflows)
 #' library(recipes)

--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -65,7 +65,7 @@ orbital.model_fit <- function(
   }
 
   if (is.language(res)) {
-    res <- deparse1(res, control = "digits17")
+    res <- deparse_exact(res)
   }
 
   res <- namespace_case_when(res)

--- a/R/separate-trees.R
+++ b/R/separate-trees.R
@@ -14,7 +14,7 @@ tree_columns <- function(trees, prefix, batch_size = 50) {
 
   tree_strs <- vapply(
     trees,
-    function(e) deparse1(e, control = "digits17"),
+    deparse_exact,
     character(1)
   )
 
@@ -61,6 +61,6 @@ separate_trees_eqs <- function(x, prefix, trees = NULL, batch_size = 50) {
 
   c(
     cols$eqs,
-    stats::setNames(deparse1(combined, control = "digits17"), prefix)
+    stats::setNames(deparse_exact(combined), prefix)
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,11 +1,73 @@
+# Write a double as the shortest decimal that R reads back unchanged.
+#
+# `%.17g` is correctly rounded, but R's decimal parser is not: it accumulates
+# the mantissa as a double, so a 17-digit literal can land one ulp away from
+# the value that produced it. That is invisible in a linear predictor and
+# decisive in a tree, whose cutpoints sit on values realized by training rows,
+# where one ulp flips `<=` and sends a row down the other branch.
+#
+# Fewer digits means less accumulated error, so trying shortest-first both
+# keeps the equations readable and round-trips more often than `%.17g` does.
+# Some doubles no decimal literal reaches; those fall back to `%.17g`, which is
+# at least the closest decimal to the value.
+format_double <- function(x) {
+  if (!is.finite(x)) {
+    return(deparse1(x, control = "digits17"))
+  }
+
+  candidates <- sprintf("%.*g", 1:17, x)
+  candidates <- candidates[as.numeric(candidates) == x]
+
+  if (length(candidates) == 0) {
+    return(sprintf("%.17g", x))
+  }
+
+  # Shortest by width rather than by digits, since `%g` switches to scientific
+  # notation on its own: `10` asked for one digit comes back as `1e+01`.
+  candidates[which.min(nchar(candidates))]
+}
+
 # Format numeric values with full precision for SQL/expression serialization
-# Uses digits17 control to ensure IEEE 754 round-trip accuracy
 format_numeric <- function(x) {
-  vapply(x, function(e) deparse1(e, control = "digits17"), character(1))
+  vapply(x, format_double, character(1))
+}
+
+# Everything `format_double()` can produce, and nothing that needs quoting for
+# any other reason. Numeric literals are re-quoted on their way through
+# `deparse()` because they are carried as symbols; this takes the quotes back
+# off again.
+numeric_literal_rx <- "`(-?[0-9]+([.][0-9]+)?(e[+-]?[0-9]+)?)`"
+
+# Deparse an expression, writing every double the way `format_double()` does.
+#
+# `deparse()` has no hook for formatting literals, so each one is swapped for a
+# symbol carrying the text to emit and unquoted again afterwards.
+deparse_exact <- function(x) {
+  out <- deparse1(exact_literals(x), control = "digits17")
+  gsub(numeric_literal_rx, "\\1", out)
+}
+
+exact_literals <- function(x) {
+  if (is.double(x) && length(x) == 1 && !is.na(x)) {
+    return(as.name(format_double(x)))
+  }
+
+  if (!is.call(x)) {
+    return(x)
+  }
+
+  for (i in seq_along(x)) {
+    # A call can hold empty arguments, which cannot be fetched or reassigned.
+    if (!identical(x[[i]], quote(expr = ))) {
+      x[[i]] <- exact_literals(x[[i]])
+    }
+  }
+
+  x
 }
 
 # Build linear predictor expression with full numeric precision
-# Replacement for tidypredict::.build_linear_pred() that uses digits17
+# Replacement for tidypredict::.build_linear_pred() that keeps full precision
 build_linear_pred <- function(coef_names, coef_values) {
   terms <- character(0)
   for (i in seq_along(coef_names)) {
@@ -31,7 +93,7 @@ build_linear_pred <- function(coef_names, coef_values) {
 # Deparse a list of expressions, as returned by tidypredict's extractor
 # generics, into the character equations orbital passes around. Names are kept.
 deparse_eqs <- function(x) {
-  vapply(x, function(e) deparse1(e, control = "digits17"), character(1))
+  vapply(x, deparse_exact, character(1))
 }
 
 namespace_case_when <- function(x) {

--- a/man/orbital.Rd
+++ b/man/orbital.Rd
@@ -56,6 +56,28 @@ These objects will not be useful by themselves. They can be used to
 \link[=predict.orbital_class]{predict()} with, or to generate code using functions
 such as \code{\link[=orbital_sql]{orbital_sql()}} or \code{\link[=orbital_dt]{orbital_dt()}}.
 }
+\section{Numeric precision}{
+
+An orbital object holds its equations as text, so every number a model
+carries is written out as a decimal and read back when the object is used.
+R's decimal parser is not correctly rounded, and for some values no decimal
+literal reads back to exactly the number the model produced. orbital writes
+the shortest decimal that does read back unchanged, and the closest decimal
+otherwise, so a coefficient can end up one unit in the last place away from
+the fitted value.
+
+For nearly every model that is orders of magnitude below the model's own
+uncertainty and can be ignored. It matters for trees that split on a value
+computed from several columns rather than on a raw column, such as the
+oblique forests of \code{rand_forest()} with the \code{"aorsf"} engine. Those splits
+are placed at combinations realized by training rows, so the comparison at a
+split is an exact tie for many rows, and the smallest possible difference is
+enough to send a row down the other branch. Its prediction then moves by the
+distance between two leaves rather than by a rounding error, and predictions
+can differ from \code{predict()} on the original fit for a meaningful share of
+rows.
+}
+
 \examples{
 \dontshow{if (rlang::is_installed(c("recipes", "tidypredict", "workflows"))) withAutoprint(\{ # examplesIf}
 library(workflows)

--- a/tests/testthat/test-classification-helpers.R
+++ b/tests/testthat/test-classification-helpers.R
@@ -293,8 +293,8 @@ test_that("sum_tree_expressions sums and deparses correctly", {
   expect_identical(
     result,
     c(
-      a = "(case_when(x > 1 ~ 0.5, .default = 0.29999999999999999)) + (case_when(x > 2 ~ 0.59999999999999998, .default = 0.40000000000000002))",
-      b = "(case_when(x > 1 ~ 0.5, .default = 0.29999999999999999))"
+      a = "(case_when(x > 1 ~ 0.5, .default = 0.3)) + (case_when(x > 2 ~ 0.6, .default = 0.4))",
+      b = "(case_when(x > 1 ~ 0.5, .default = 0.3))"
     )
   )
 })
@@ -409,9 +409,10 @@ test_that("format_separate_trees preserves numeric precision", {
 
   result <- orbital:::format_separate_trees(list(tree), ".pred")
 
-  # Verify high precision is preserved (at least 15 significant digits)
-  expect_match(result[[1]], "1\\.234567890123456")
-  expect_match(result[[1]], "0\\.987654321098765")
+  expect_identical(
+    rlang::parse_expr(result[[1]]),
+    tree
+  )
 })
 
 test_that("format_multiclass_logits_separate returns correct structure", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -34,6 +34,54 @@ test_that("format_numeric handles zero", {
   expect_equal(result, "0")
 })
 
+test_that("format_double round-trips whenever a decimal can", {
+  set.seed(1234)
+  vals <- c(runif(500), rnorm(500) * 1e5, runif(500) * 1e-8)
+
+  # R's parser is not correctly rounded, so some doubles no decimal literal
+  # reaches at all. Every one that any `%g` width reaches must round-trip.
+  reachable <- vapply(
+    vals,
+    function(x) any(as.numeric(sprintf("%.*g", 1:17, x)) == x),
+    logical(1)
+  )
+  round_trips <- as.numeric(vapply(vals, orbital:::format_double, "")) == vals
+
+  expect_identical(round_trips[reachable], rep(TRUE, sum(reachable)))
+})
+
+test_that("format_double round-trips more often than digits17", {
+  set.seed(1234)
+  vals <- runif(500)
+
+  expect_gt(
+    sum(as.numeric(vapply(vals, orbital:::format_double, "")) == vals),
+    sum(as.numeric(sprintf("%.17g", vals)) == vals)
+  )
+})
+
+test_that("format_double picks the shortest readable form", {
+  expect_equal(orbital:::format_double(10), "10")
+  expect_equal(orbital:::format_double(0.3), "0.3")
+  expect_equal(orbital:::format_double(-1e-08), "-1e-08")
+})
+
+test_that("deparse_exact round-trips expressions", {
+  eq <- rlang::expr(dplyr::case_when(
+    x > 1.234567890123456 ~ 0.98765432109876,
+    y <= -3.5e-08 ~ 42,
+    .default = 0.3
+  ))
+
+  expect_identical(rlang::parse_expr(orbital:::deparse_exact(eq)), eq)
+})
+
+test_that("deparse_exact keeps missing arguments", {
+  eq <- rlang::expr(x[, 1.5])
+
+  expect_identical(rlang::parse_expr(orbital:::deparse_exact(eq)), eq)
+})
+
 test_that("build_linear_pred creates correct expression", {
   coef_names <- c("(Intercept)", "x", "y")
   coef_values <- c(1.5, 2.0, 3.0)


### PR DESCRIPTION
`orbital()` deparsed every number with `control = "digits17"`, but R's decimal parser is not correctly rounded, so a 17-digit literal can be read back one ulp away from the value it came from. That is invisible in a linear predictor and decisive in a tree whose cutpoints sit on values realized by training rows, where one ulp flips `<=` and sends a row down the other branch. Writing the shortest decimal R reads back unchanged narrows the aorsf gap in #165 from 0.024 to 0.018 (892 to 647 of 2930 rows landing on the wrong branch), and makes the equations shorter and easier to read.

For roughly 8% of doubles no decimal literal at any width parses back to the right value, so a residual difference is inherent to storing equations as text. Closing it entirely would need hex literals or a scaled-integer form (`4586233270891954 * 2^-52`), both too unreadable for the equations users see, so the remaining gap is documented under "Numeric precision" in `?orbital` instead.