### PR TITLE
Refuse bare model fits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
 
 * `estimate_orbital_size()` now errors for a workflow whose model it has no estimate for, rather than counting that model as zero characters and returning the recipe's size as the whole workflow's. The model is usually the bulk of the expression, so the number it returned could be off by orders of magnitude while looking ordinary, and it did not move as the model's hyperparameters changed. (#167)
 
+* `orbital()` now errors for a bare model fit, which was never documented input, rather than returning something that looked like a result. A regression fit handed in directly took the classification path whatever the model was, so `orbital(rpart::rpart(mpg ~ ., mtcars))` came back as a character vector named `orbital_tmp_class_name` with no error and no warning. Fit the model with `parsnip::fit()`, or use a workflow, as the documentation has always described. (#113)
+
 * `orbital()` now uses the model's own class order for binary probabilities, rather than assuming it matches the order of the outcome's factor levels. Every engine but h2o orders them the same way, so only h2o models were affected, and only when the outcome's levels were not in sorted order; for those both probability columns were swapped and the class inverted. (#166)
 
 * `orbital()` now returns the correct classes for `svm_linear()` models with the `"LiblineaR"` engine. The sign of the decision value was read as meaning the second outcome level, but LiblineaR orients it by its own class order, which need not match the order of the outcome's factor levels. When the two disagreed every class was inverted. (#164)

--- a/R/model-catboost.R
+++ b/R/model-catboost.R
@@ -6,8 +6,10 @@ orbital.catboost.Model <- function(
   type = NULL,
   lvl = NULL,
   separate_trees = FALSE,
-  prefix = ".pred"
+  prefix = ".pred",
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
 
   type <- default_type(type)

--- a/R/model-earth.R
+++ b/R/model-earth.R
@@ -4,8 +4,10 @@ orbital.earth <- function(
   ...,
   mode = c("classification", "regression"),
   type = NULL,
-  lvl = NULL
+  lvl = NULL,
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/model-glm.R
+++ b/R/model-glm.R
@@ -4,8 +4,10 @@ orbital.glm <- function(
   ...,
   mode = c("classification", "regression"),
   type = NULL,
-  lvl = NULL
+  lvl = NULL,
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/model-glmnet.R
+++ b/R/model-glmnet.R
@@ -5,8 +5,10 @@ orbital.glmnet <- function(
   mode = c("classification", "regression"),
   type = NULL,
   lvl = NULL,
-  penalty = NULL
+  penalty = NULL,
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/model-lightgbm.R
+++ b/R/model-lightgbm.R
@@ -6,8 +6,10 @@ orbital.lgb.Booster <- function(
   type = NULL,
   lvl = NULL,
   separate_trees = FALSE,
-  prefix = ".pred"
+  prefix = ".pred",
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/model-partykit.R
+++ b/R/model-partykit.R
@@ -4,8 +4,10 @@ orbital.constparty <- function(
   ...,
   mode = c("classification", "regression"),
   type = NULL,
-  lvl = NULL
+  lvl = NULL,
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/model-randomForest.R
+++ b/R/model-randomForest.R
@@ -6,8 +6,10 @@ orbital.randomForest <- function(
   type = NULL,
   lvl = NULL,
   separate_trees = FALSE,
-  prefix = ".pred"
+  prefix = ".pred",
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/model-ranger.R
+++ b/R/model-ranger.R
@@ -6,8 +6,10 @@ orbital.ranger <- function(
   type = NULL,
   lvl = NULL,
   separate_trees = FALSE,
-  prefix = ".pred"
+  prefix = ".pred",
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/model-rpart.R
+++ b/R/model-rpart.R
@@ -4,8 +4,10 @@ orbital.rpart <- function(
   ...,
   mode = c("classification", "regression"),
   type = NULL,
-  lvl = NULL
+  lvl = NULL,
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/model-xgboost.R
+++ b/R/model-xgboost.R
@@ -7,8 +7,10 @@ orbital.xgb.Booster <- function(
 
   lvl = NULL,
   separate_trees = FALSE,
-  prefix = ".pred"
+  prefix = ".pred",
+  .from_parsnip = FALSE
 ) {
+  check_bare_fit(x, .from_parsnip)
   mode <- rlang::arg_match(mode)
   type <- default_type(type)
 

--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -29,7 +29,8 @@ orbital.model_fit <- function(
         type = type,
         lvl = x$lvl,
         separate_trees = separate_trees,
-        prefix = prefix
+        prefix = prefix,
+        .from_parsnip = TRUE
       )
     } else {
       res <- rlang::exec(
@@ -40,6 +41,7 @@ orbital.model_fit <- function(
         lvl = x$lvl,
         separate_trees = separate_trees,
         prefix = prefix,
+        .from_parsnip = TRUE,
         !!!extra_args
       )
     }
@@ -72,6 +74,31 @@ orbital.model_fit <- function(
   res <- set_pred_names(res, x, mode, type, prefix)
 
   new_orbital_class(res)
+}
+
+# The model methods are registered on an exported generic, so a bare fit reaches
+# them even though `orbital()` documents only workflow, parsnip, and recipe
+# input. They cannot be unregistered: `orbital.model_fit()` reaches them by
+# dispatching on `x$fit`. So the internal caller marks itself instead.
+#
+# Without this a bare fit takes the classification branch whatever the model is,
+# because `mode` defaults to `c("classification", "regression")` and
+# `arg_match()` takes the first. A bare regression `rpart` came back as a
+# character vector named `orbital_tmp_class_name`: an internal placeholder, no
+# error, no warning.
+check_bare_fit <- function(x, from_parsnip, call = rlang::caller_env()) {
+  if (from_parsnip) {
+    return(invisible())
+  }
+
+  cli::cli_abort(
+    c(
+      "{.arg x} must be a workflow, parsnip, or recipe object, not a bare
+       {.cls {class(x)[1]}} fit.",
+      i = "Fit the model with {.fn parsnip::fit} first."
+    ),
+    call = call
+  )
 }
 
 has_orbital_method <- function(x) {

--- a/tests/testthat/_snaps/parsnip.md
+++ b/tests/testthat/_snaps/parsnip.md
@@ -6,6 +6,33 @@
       Error in `orbital()`:
       ! A model of class <train.kknn> is not supported.
 
+# bare model fits are refused
+
+    Code
+      orbital(rpart::rpart(mpg ~ ., mtcars))
+    Condition
+      Error in `orbital()`:
+      ! `x` must be a workflow, parsnip, or recipe object, not a bare <rpart> fit.
+      i Fit the model with `parsnip::fit()` first.
+
+---
+
+    Code
+      orbital(partykit::ctree(mpg ~ ., mtcars))
+    Condition
+      Error in `orbital()`:
+      ! `x` must be a workflow, parsnip, or recipe object, not a bare <constparty> fit.
+      i Fit the model with `parsnip::fit()` first.
+
+# bare fits that already errored now say why
+
+    Code
+      orbital(randomForest::randomForest(mpg ~ ., mtcars))
+    Condition
+      Error in `orbital()`:
+      ! `x` must be a workflow, parsnip, or recipe object, not a bare <randomForest.formula> fit.
+      i Fit the model with `parsnip::fit()` first.
+
 # errors from native methods are not swallowed by the fallback
 
     Code

--- a/tests/testthat/test-parsnip.R
+++ b/tests/testthat/test-parsnip.R
@@ -32,6 +32,30 @@ test_that("has_orbital_method() detects native methods", {
   expect_false(has_orbital_method(structure(list(), class = "train.kknn")))
 })
 
+test_that("bare model fits are refused", {
+  skip_if_not_installed("rpart")
+  skip_if_not_installed("partykit")
+
+  # Regression fits used to take the classification branch and return a
+  # character vector named `orbital_tmp_class_name`, with no error.
+  expect_snapshot(error = TRUE, orbital(rpart::rpart(mpg ~ ., mtcars)))
+  expect_snapshot(
+    error = TRUE,
+    orbital(partykit::ctree(mpg ~ ., mtcars))
+  )
+})
+
+test_that("bare fits that already errored now say why", {
+  skip_if_not_installed("randomForest")
+
+  # This errored before, but with "Model is not a classification model.",
+  # which described an internal symptom rather than the actual mistake.
+  expect_snapshot(
+    error = TRUE,
+    orbital(randomForest::randomForest(mpg ~ ., mtcars))
+  )
+})
+
 test_that("errors from native methods are not swallowed by the fallback", {
   skip_if_not_installed("parsnip")
   skip_if_not_installed("tidypredict")

--- a/tests/testthat/test-separate-trees.R
+++ b/tests/testthat/test-separate-trees.R
@@ -18,8 +18,15 @@ expect_separate_matches_collapsed <- function(
   data,
   mode = "regression"
 ) {
-  collapsed <- orbital(model, mode = mode)
-  split <- orbital(model, mode = mode, separate_trees = TRUE)
+  # These exercise the model methods directly rather than through a fitted
+  # workflow, so they mark themselves the way `orbital.model_fit()` does.
+  collapsed <- orbital(model, mode = mode, .from_parsnip = TRUE)
+  split <- orbital(
+    model,
+    mode = mode,
+    separate_trees = TRUE,
+    .from_parsnip = TRUE
+  )
 
   expect_equal(
     eval_tree_eqs(split, data)[[".pred"]],
@@ -111,7 +118,12 @@ test_that("separate trees keep the missing-value guard the collapsed path has", 
   incomplete <- mtcars[1:2, ]
   incomplete$wt[[1]] <- NA_real_
 
-  eqs <- orbital(model, mode = "regression", separate_trees = TRUE)
+  eqs <- orbital(
+    model,
+    mode = "regression",
+    separate_trees = TRUE,
+    .from_parsnip = TRUE
+  )
   pred <- eval_tree_eqs(eqs, incomplete)[[".pred"]]
 
   # The second row still scores, so the guard is not simply blanking the column.


### PR DESCRIPTION
`orbital()` documents its input as a workflow, parsnip, or recipe object, but bare model fits reach the `orbital.<class>` methods anyway, because those are registered methods on an exported generic. They did not fail consistently: a bare regression `rpart`, `earth`, `ctree`, or `glm` took the classification branch whatever the model was, and returned a character vector named `orbital_tmp_class_name` with no error and no warning. This makes all ten model methods refuse bare fits, which is the same refuse-rather-than-fabricate line taken in #156 and #167.

The methods cannot simply be unregistered, since `orbital.model_fit()` reaches them by dispatching on `x$fit`, so the internal caller marks itself with an undocumented `.from_parsnip` flag instead. This closes only the defect; inferring mode and levels so bare fits actually work is the feature half of #113 and is left open.

Part of #113.