### PR TITLE
Catch up with tidypredict's newly supported models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     rlang
 Suggests:
     agua,
+    aorsf,
     arrow,
     baguette,
     bonsai,

--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,8 @@
 
 ## Improvements
 
+* `orbital(separate_trees = TRUE)` now works for `rand_forest()` with the `"aorsf"` and `"partykit"` engines. The argument used to be accepted and silently ignored for every model orbital has no method of its own for; it is now honoured for any regression ensemble whose per-tree expressions tidypredict exposes. (#173)
+
 * `orbital()` now supports classification models that reach the tidypredict fallback, rather than refusing them. This covers multiclass probability models such as `MASS::lda()`, models returning an uncalibrated decision value such as `LiblineaR` SVMs, and models predicting a class label directly such as `C50::C5.0()`. (#159)
 
 * `orbital()` refuses `type = "prob"` for models that have no probability to give, rather than fabricating one. A decision value is uncalibrated, so putting it through a logistic would invent a calibration the model does not have. (#159)

--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,8 @@
 
 * `pls()` with the `"mixOmics"` engine is now supported for regression and for `type = "prob"`. `type = "class"` is refused, since mixOmics assigns a class by distance to the class centroid rather than by the largest per-level value. (#163)
 
+* `rand_forest()` with the `"aorsf"` engine is now supported for regression. Classification is refused, since aorsf votes across the forest and exposes no probability. Note that aorsf splits on observed linear-combination values, so a row that lands exactly on a split boundary can take the other branch than `predict()` did. (#173)
+
 * `rand_forest()` with the `"partykit"` engine is now supported for regression. (#161)
 
 * `rule_fit()` with the `"xrf"` engine is now supported for regression and for binary classification. Multiclass outcomes are refused, since xrf only fits Gaussian and binomial models. (#164)

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * `C5_rules()` with the `"C5.0"` engine is now supported for `type = "class"`. (#161)
 
+* `decision_tree()` with the `"C5.0"` engine is now supported for `type = "class"`. Its leaves carry a class label rather than class counts, so `type = "prob"` is refused. (#173)
+
 * `discrim_linear()` and `discrim_quad()` with the `"MASS"` engine are now supported for `type = "class"` and `type = "prob"`. (#160)
 
 * `discrim_linear()` with the `"mda"`, `"sda"`, and `"sparsediscrim"` engines is now supported for `type = "class"` and `type = "prob"`. (#163)

--- a/R/fallback-routing.R
+++ b/R/fallback-routing.R
@@ -10,6 +10,45 @@
 # expression both for a probability and for an uncalibrated decision value, and
 # cutting a decision value at 0.5 would give silently wrong classes for every
 # row whose value falls between 0 and 0.5.
+# The fitted equations for a model orbital has no method of its own for.
+#
+# `separate_trees` is honoured here for any ensemble tidypredict exposes trees
+# for, so that a model reaching the fallback gets the same one-column-per-tree
+# treatment as one of orbital's native methods. Only regression takes that path:
+# the classification shapes are assembled by `route_fallback()` below from a
+# result it expects to be a single expression or a per-level list, neither of
+# which a column-per-tree vector is.
+fallback_eqs <- function(x, mode, separate_trees, prefix) {
+  if (separate_trees && mode == "regression" && has_tree_methods(x$fit)) {
+    return(separate_trees_eqs(x$fit, prefix))
+  }
+
+  tidypredict::tidypredict_fit(x)
+}
+
+# Both generics are required, not just the first. tidypredict documents them as
+# a set for exactly this reason: trees that cannot be recombined are only good
+# for producing a wrong answer.
+#
+# The lookup is made in tidypredict's namespace because that is where these
+# generics live. Without it the search starts from orbital's namespace, which
+# does not import them, and every model comes back as having no method.
+has_tree_methods <- function(x) {
+  ns <- asNamespace("tidypredict")
+
+  has_method <- function(generic) {
+    any(vapply(
+      class(x),
+      function(cls) {
+        !is.null(utils::getS3method(generic, cls, optional = TRUE, envir = ns))
+      },
+      logical(1)
+    ))
+  }
+
+  has_method("tidypredict_trees") && has_method("tidypredict_combine_trees")
+}
+
 route_fallback <- function(res, x, mode, type, call = rlang::caller_env()) {
   if (mode != "classification") {
     return(res)

--- a/R/orbital.R
+++ b/R/orbital.R
@@ -16,8 +16,8 @@
 #'   predictions for classification models. Defaults to `NULL` which defaults to
 #'   `"numeric"` for regression models and `"class"` for classification models.
 #' @param separate_trees A single logical. For tree ensemble models (xgboost,
-#'   lightgbm, catboost, ranger, randomForest), should each tree be output as a
-#'   separate expression? This can improve performance when predicting in
+#'   lightgbm, catboost, ranger, randomForest, aorsf, partykit), should each
+#'   tree be output as a separate expression? This can improve performance when predicting in
 #'   databases by allowing parallel evaluation of trees. Defaults to `FALSE`.
 #'   See `vignette("separate-trees")` for details.
 #'

--- a/R/parsnip.R
+++ b/R/parsnip.R
@@ -47,7 +47,7 @@ orbital.model_fit <- function(
     }
   } else {
     res <- tryCatch(
-      tidypredict::tidypredict_fit(x),
+      fallback_eqs(x, mode, separate_trees, prefix),
       # tidypredict signals this class when no method handles the model at all.
       tidypredict_unsupported_model = function(cnd) {
         abort_unsupported_model(x)

--- a/man/orbital.Rd
+++ b/man/orbital.Rd
@@ -23,8 +23,8 @@ predictions for classification models. Defaults to \code{NULL} which defaults to
 \code{"numeric"} for regression models and \code{"class"} for classification models.}
 
 \item{separate_trees}{A single logical. For tree ensemble models (xgboost,
-lightgbm, catboost, ranger, randomForest), should each tree be output as a
-separate expression? This can improve performance when predicting in
+lightgbm, catboost, ranger, randomForest, aorsf, partykit), should each
+tree be output as a separate expression? This can improve performance when predicting in
 databases by allowing parallel evaluation of trees. Defaults to \code{FALSE}.
 See \code{vignette("separate-trees")} for details.}
 }

--- a/tests/testthat/_snaps/model-C50.md
+++ b/tests/testthat/_snaps/model-C50.md
@@ -1,3 +1,13 @@
+# decision_tree(C5.0) errors for type = prob
+
+    Code
+      orbital(fit, type = "prob")
+    Condition
+      Error in `orbital()`:
+      ! "prob" predictions are not available for this model.
+      i It predicts a class directly, with no probability behind it.
+      i Use `type = "class"` instead.
+
 # boost_tree(C5.0) errors for type = prob
 
     Code

--- a/tests/testthat/_snaps/model-aorsf.md
+++ b/tests/testthat/_snaps/model-aorsf.md
@@ -1,0 +1,10 @@
+# rand_forest(aorsf) errors for classification
+
+    Code
+      orbital(fit)
+    Condition
+      Error in `aorsf_check_supported()`:
+      ! Classification models are not supported for aorsf.
+      i Only regression models can be converted to tidy formulas.
+      i Classification requires a voting mechanism that cannot be expressed as a single formula.
+

--- a/tests/testthat/test-model-C50.R
+++ b/tests/testthat/test-model-C50.R
@@ -67,6 +67,29 @@ test_that("boost_tree(C5.0) works with more than one boosting round", {
   )
 })
 
+test_that("decision_tree(C5.0) works with type = class", {
+  skip_if_no_C50()
+
+  spec <- parsnip::decision_tree(mode = "classification", engine = "C5.0")
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  preds <- predict(orbital(fit, type = "class"), iris)
+
+  expect_identical(
+    preds$.pred_class,
+    as.character(predict(fit, iris)$.pred_class)
+  )
+})
+
+test_that("decision_tree(C5.0) errors for type = prob", {
+  skip_if_no_C50()
+
+  spec <- parsnip::decision_tree(mode = "classification", engine = "C5.0")
+  fit <- parsnip::fit(spec, Species ~ ., iris)
+
+  expect_snapshot(error = TRUE, orbital(fit, type = "prob"))
+})
+
 test_that("C5_rules() works with type = class", {
   skip_if_no_C50()
   skip_if_not_installed("rules")

--- a/tests/testthat/test-model-aorsf.R
+++ b/tests/testthat/test-model-aorsf.R
@@ -1,0 +1,65 @@
+# aorsf splits on observed linear-combination values, so a training row can land
+# exactly on a split boundary where floating-point drift flips the branch. These
+# tests predict on jittered data, where such exact ties do not occur.
+skip_if_no_aorsf <- function() {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("tidypredict")
+  skip_if_not_installed("bonsai")
+  skip_if_not_installed("aorsf")
+}
+
+jittered_mtcars <- function() {
+  set.seed(99)
+  df <- mtcars
+  df[] <- lapply(mtcars, function(x) x + stats::rnorm(length(x), 0, 0.01))
+  df
+}
+
+test_that("rand_forest(aorsf) works for regression", {
+  skip_if_no_aorsf()
+
+  set.seed(1)
+  spec <- parsnip::set_engine(
+    parsnip::rand_forest(mode = "regression", trees = 20),
+    "aorsf"
+  )
+  fit <- parsnip::fit(spec, mpg ~ wt + cyl + disp + hp, mtcars)
+
+  new_data <- jittered_mtcars()
+  preds <- predict(orbital(fit), new_data)
+
+  expect_named(preds, ".pred")
+  expect_equal(preds$.pred, predict(fit, new_data)$.pred)
+})
+
+test_that("rand_forest(aorsf) works with custom prefix", {
+  skip_if_no_aorsf()
+
+  set.seed(1)
+  spec <- parsnip::set_engine(
+    parsnip::rand_forest(mode = "regression", trees = 5),
+    "aorsf"
+  )
+  fit <- parsnip::fit(spec, mpg ~ wt + cyl, mtcars)
+
+  preds <- predict(orbital(fit, prefix = "my_pred"), jittered_mtcars())
+
+  expect_named(preds, "my_pred")
+})
+
+test_that("rand_forest(aorsf) errors for classification", {
+  skip_if_no_aorsf()
+
+  set.seed(1)
+  spec <- parsnip::set_engine(
+    parsnip::rand_forest(mode = "classification", trees = 5),
+    "aorsf"
+  )
+  fit <- parsnip::fit(
+    spec,
+    Species ~ .,
+    droplevels(iris[iris$Species != "setosa", ])
+  )
+
+  expect_snapshot(error = TRUE, orbital(fit))
+})

--- a/tests/testthat/test-separate-trees.R
+++ b/tests/testthat/test-separate-trees.R
@@ -129,3 +129,91 @@ test_that("separate trees keep the missing-value guard the collapsed path has", 
   # The second row still scores, so the guard is not simply blanking the column.
   expect_equal(is.na(pred), c(TRUE, FALSE))
 })
+
+# The fallback path: models orbital has no method of its own for, whose trees
+# come from tidypredict's extractors. These go through a fitted parsnip model
+# rather than a bare fit, since that is where the fallback lives.
+expect_fallback_separate_matches_collapsed <- function(fit, data) {
+  collapsed <- orbital(fit)
+  split <- orbital(fit, separate_trees = TRUE)
+
+  expect_gt(length(split), length(collapsed))
+  expect_equal(
+    eval_tree_eqs(split, data)[[".pred"]],
+    eval_tree_eqs(collapsed, data)[[".pred"]]
+  )
+}
+
+test_that("separate trees work for rand_forest(aorsf)", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("bonsai")
+  skip_if_not_installed("aorsf")
+
+  set.seed(1)
+  spec <- parsnip::set_engine(
+    parsnip::rand_forest(mode = "regression", trees = 3),
+    "aorsf"
+  )
+  fit <- parsnip::fit(spec, mpg ~ wt + cyl + disp, mtcars)
+
+  # aorsf splits on observed values, so a training row can sit exactly on a
+  # split boundary. Jittering keeps both paths off those ties.
+  set.seed(99)
+  data <- mtcars
+  data[] <- lapply(mtcars, function(x) x + stats::rnorm(length(x), 0, 0.01))
+
+  expect_fallback_separate_matches_collapsed(fit, data)
+})
+
+test_that("separate trees work for rand_forest(partykit)", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("bonsai")
+  skip_if_not_installed("partykit")
+
+  set.seed(1)
+  spec <- parsnip::set_engine(
+    parsnip::rand_forest(mode = "regression", trees = 3),
+    "partykit"
+  )
+  fit <- parsnip::fit(spec, mpg ~ wt + cyl, mtcars)
+
+  expect_fallback_separate_matches_collapsed(fit, mtcars)
+})
+
+# Batching divides the trees into subtotals, so the divisor of an averaging
+# ensemble has to come from the model rather than from the number of subtotals
+# handed back.
+test_that("separate trees match the collapsed expression when batching a forest that averages", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("bonsai")
+  skip_if_not_installed("partykit")
+
+  set.seed(1)
+  spec <- parsnip::set_engine(
+    parsnip::rand_forest(mode = "regression", trees = 60),
+    "partykit"
+  )
+  fit <- parsnip::fit(spec, mpg ~ wt + cyl, mtcars)
+
+  split <- orbital(fit, separate_trees = TRUE)
+
+  expect_match(names(split), "_sum_", all = FALSE)
+  expect_equal(
+    eval_tree_eqs(split, mtcars)[[".pred"]],
+    eval_tree_eqs(orbital(fit), mtcars)[[".pred"]]
+  )
+})
+
+test_that("separate_trees is ignored for a fallback model with no trees", {
+  skip_if_not_installed("parsnip")
+  skip_if_not_installed("nnet")
+
+  set.seed(1)
+  fit <- parsnip::fit(
+    parsnip::set_engine(parsnip::mlp(mode = "regression"), "nnet"),
+    mpg ~ wt + cyl,
+    mtcars
+  )
+
+  expect_identical(orbital(fit, separate_trees = TRUE), orbital(fit))
+})

--- a/vignettes/separate-trees.Rmd
+++ b/vignettes/separate-trees.Rmd
@@ -101,12 +101,16 @@ The `separate_trees` argument works with the following tree ensemble models:
 | `boost_tree()` | catboost | Yes | Yes |
 | `rand_forest()` | ranger | Yes | Yes |
 | `rand_forest()` | randomForest | Yes | Yes |
+| `rand_forest()` | aorsf | Yes | Not supported at all |
+| `rand_forest()` | partykit | Yes | Not supported at all |
 
 For multiclass classification, trees are separated per class before the final softmax transformation is applied.
 
+The last two are regression-only in the "Not supported" sense that orbital cannot translate them for classification in the first place, rather than that `separate_trees` is the missing piece.
+
 ### Models where the argument has no effect
 
-`separate_trees` is accepted by `orbital()` for every model, but only the five above act on it. Everything else silently produces the same single combined expression it would have produced with the default. Setting it is never an error and never changes the predictions, so a query that looks unchanged is the expected result rather than a sign something went wrong.
+`separate_trees` is accepted by `orbital()` for every model, but only the seven above act on it. Everything else silently produces the same single combined expression it would have produced with the default. Setting it is never an error and never changes the predictions, so a query that looks unchanged is the expected result rather than a sign something went wrong.
 
 This is worth knowing because several supported models are tree ensembles that nonetheless ignore it:
 
@@ -116,7 +120,6 @@ This is worth knowing because several supported models are tree ensembles that n
 | `bart()` | dbarts | Sums over posterior draws, not over separable trees |
 | `boost_tree()` | C5.0 | Confidence-weighted vote that cannot be recombined arithmetically |
 | `C5_rules()` | C5.0 | As above |
-| `rand_forest()` | partykit | Not yet wired up; the underlying model could support it |
 | `rule_fit()` | xrf, h2o | Emitted as a rule set rather than as individual trees |
 | `boost_tree()` | h2o_gbm | Translated through h2o's own export, which does not expose per-tree pieces |
 

--- a/vignettes/supported-models.Rmd
+++ b/vignettes/supported-models.Rmd
@@ -68,6 +68,7 @@ tibble::tribble(
   "`nearest_neighbor()`", "`any`",              "❌",     "❌",    "❌",
   "`null_model()`",       "`\"parsnip\"`",      "✅",     "✅",    "✅",
   "`pls()`",              "`\"mixOmics\"`",     "✅",     "❌",    "✅",
+  "`rand_forest()`",      "`\"aorsf\"`",        "✅",     "❌",    "❌",
   "`rand_forest()`",      "`\"partykit\"`",     "✅",     "❌",    "❌",
   "`rand_forest()`",      "`\"randomForest\"`", "✅",     "✅",    "✅",
   "`rand_forest()`",      "`\"ranger\"`",       "✅",     "✅",    "✅",

--- a/vignettes/supported-models.Rmd
+++ b/vignettes/supported-models.Rmd
@@ -44,6 +44,7 @@ tibble::tribble(
   "`boost_tree()`",       "`\"xgboost\"`",      "✅",     "✅",    "✅",
   "`C5_rules()`",         "`\"C5.0\"`",         "❌",     "✅",    "❌",
   "`cubist_rules()`",     "`\"Cubist\"`",       "✅",     "❌",    "❌",
+  "`decision_tree()`",    "`\"C5.0\"`",         "❌",     "✅",    "❌",
   "`decision_tree()`",    "`\"partykit\"`",     "✅",     "✅",    "✅",
   "`decision_tree()`",    "`\"rpart\"`",        "✅",     "✅",    "✅",
   "`discrim_flexible()`", "`\"earth\"`",        "❌",     "❌",    "❌",
@@ -107,7 +108,7 @@ tibble::tribble(
 
 The two classification columns are separate because not every model produces both, and orbital refuses a type rather than inventing it.
 
-**Class without probability.** Some models predict a label directly and never compute a probability at all. `bag_tree()` and `boost_tree()` with the `"C5.0"` engine, `C5_rules()`, and `bag_tree()` with `"rpart"` all reach their answer by voting across an ensemble; the vote yields a winner, not a distribution. `svm_linear()` with `"LiblineaR"` produces a *decision value*, the signed distance from the separating hyperplane. Its sign gives the class, but its magnitude is uncalibrated: it is not a probability and does not become one by being passed through a logistic. Doing that would attach a confidence the model never estimated, so `type = "prob"` is refused for all of these.
+**Class without probability.** Some models predict a label directly and never compute a probability at all. `bag_tree()` and `boost_tree()` with the `"C5.0"` engine, `C5_rules()`, and `bag_tree()` with `"rpart"` all reach their answer by voting across an ensemble; the vote yields a winner, not a distribution. `decision_tree()` with `"C5.0"` is the single-tree version of the same thing: it labels each leaf with a class rather than with class counts. `svm_linear()` with `"LiblineaR"` produces a *decision value*, the signed distance from the separating hyperplane. Its sign gives the class, but its magnitude is uncalibrated: it is not a probability and does not become one by being passed through a logistic. Doing that would attach a confidence the model never estimated, so `type = "prob"` is refused for all of these.
 
 **Probability without class.** `pls()` with `"mixOmics"` is the reverse case. It gives per-level values, but mixOmics assigns a class by distance to the class centroid rather than by taking the largest of those values, so the obvious `which.max()` would disagree with the model on some rows. orbital gives the probabilities and refuses `type = "class"`.
 


### PR DESCRIPTION
Two models tidypredict gained support for were already reachable through orbital's fallback but were neither tested nor listed as supported: `decision_tree()` with the `"C5.0"` engine and `rand_forest()` with the `"aorsf"` engine. This adds tests and documentation for both.

It also makes `separate_trees = TRUE` work for models that reach the fallback, rather than accepting the argument and silently ignoring it. tidypredict now exposes per-tree expressions for `cforest` and `aorsf`, so those two forests get the same one-column-per-tree treatment as the engines orbital has methods of its own for.

Depends on tidymodels/tidypredict#441, without which the batched tree columns are averaged over the number of batches instead of the number of trees.